### PR TITLE
feat(gateway): audit logging + kagetora allowlist tightening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,26 +65,37 @@ jobs:
         run: |
           timeout 5 docker run --rm mcp-airlock:test || true
 
+      - name: Build test runner image (adds shell + pytest to distroless)
+        run: |
+          docker build -f - -t mcp-airlock:test-runner . <<'EOF'
+          FROM quay.io/hummingbird/python:latest-builder AS test-deps
+          USER 0
+          RUN pip install --no-cache-dir --prefix=/usr pytest pytest-asyncio
+
+          FROM mcp-airlock:test
+          COPY --from=test-deps /usr/lib/python3.14/site-packages/ /usr/lib/python3.14/site-packages/
+          EOF
+
       - name: Run L2 integration tests in container
         run: |
           docker run --rm \
-            --entrypoint "" \
+            --entrypoint python \
             -v ${{ github.workspace }}/tests:/tests:ro \
             -e GEMINI_API_KEY="test_key_for_ci" \
             -e CLASSIFIER_MODEL_PATH="/models/prompt-guard-2-22m" \
-            mcp-airlock:test \
-            sh -c "pip install --no-cache-dir pytest pytest-asyncio && python -m pytest /tests/test_l2_integration.py -v"
+            mcp-airlock:test-runner \
+            -m pytest /tests/test_l2_integration.py -v
 
       - name: Run L3 integration tests in container
         if: env.HAS_GEMINI_KEY == 'true'
         run: |
           docker run --rm \
-            --entrypoint "" \
+            --entrypoint python \
             -v ${{ github.workspace }}/tests:/tests:ro \
             -e GEMINI_API_KEY="${{ secrets.GEMINI_API_KEY }}" \
             -e CLASSIFIER_MODEL_PATH="/models/prompt-guard-2-22m" \
-            mcp-airlock:test \
-            sh -c "pip install --no-cache-dir pytest pytest-asyncio && python -m pytest /tests/test_l3_integration.py -v"
+            mcp-airlock:test-runner \
+            -m pytest /tests/test_l3_integration.py -v
 
   validate-constitution:
     name: Constitution Validation

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Run Trivy vulnerability scanner
         continue-on-error: true
         if: github.event_name != 'pull_request'
-        uses: aquasecurity/trivy-action@0.34.1
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ env.QUAY_IMAGE }}:latest
           format: "table"

--- a/.specify/specs/006-gateway-mode/plan.md
+++ b/.specify/specs/006-gateway-mode/plan.md
@@ -1,4 +1,4 @@
-# Implementation Plan: Gateway Mode — Phase 1
+# Implementation Plan: Gateway Mode — Phase 1 + Option C
 
 > **Spec ID:** 006-gateway-mode
 > **Status:** In Progress
@@ -6,10 +6,14 @@
 
 ## Summary
 
-Phase 1: add a `gateway/` subpackage that exposes `/gateway/<profile>/mcp` endpoints
-alongside airlock's existing `/mcp` web-tools surface. Transparent proxy to
-backend MCP servers with bearer-token auth and tool-allowlist filtering on
-`tools/list` responses. No defense pipeline application yet — that's Phase 2.
+Phase 1 added a `gateway/` subpackage exposing `/gateway/<profile>/mcp` endpoints
+that proxy to backend MCP servers with bearer-token auth and tool-allowlist
+filtering on `tools/list` responses.
+
+**Option C** folds airlock's own tools into that same gateway as an in-process
+`internal://` backend and deprecates the standalone `/mcp` web-tools surface, so
+the gateway becomes the single per-consumer endpoint for everything. No defense
+pipeline application yet — that's Phase 2.
 
 ---
 
@@ -24,11 +28,7 @@ Consumer (Josui / Kagetora / future Takeda)
     │  Content-Type: application/json
     │  Body: JSON-RPC 2.0 request
     ▼
-Starlette parent app  (server.py)
-    │
-    │  route match on /gateway/{profile}/mcp
-    ▼
-gateway/app.py  GatewayHandler
+FastMCP app  —  custom_route("/gateway/{profile}/mcp")  (gateway/app.py)
     │  ┌──────────────────┐
     │  │ auth.py verify   │  bearer token vs profile config
     │  ├──────────────────┤
@@ -37,32 +37,35 @@ gateway/app.py  GatewayHandler
     │  │ router.py        │  JSON-RPC method dispatch
     │  │                  │
     │  │  initialize ────────► return gateway server info
-    │  │  tools/list ────────► aggregate from backends, filter.py applies allowlist
-    │  │  tools/call ────────► backend.py routes to correct backend
+    │  │  tools/list ────────► aggregate across backends, filter.py applies allowlist
+    │  │  tools/call ────────► dispatch by backend.is_internal
     │  │  ping ──────────────► return pong
     │  │  (other) ───────────► method-not-found
     │  └──────────────────┘
     ▼
-backend.py
-    │  mcp.client.streamable_http connection pool (one per backend per profile)
-    ▼
-Backend MCP server (mcp-slack:8005, mcp-mediawiki:8016, etc.)
+   scheme dispatch
+    ├── http(s):// ──► backend.py  ──► remote MCP server (mcp-slack:8005, …)
+    └── internal:// ─► internal.py ──► airlock's own FastMCP tool registry (in-process)
     │
-    │  response
+    │  response (both paths return the same dict / BackendCall shape)
     ▼
-filter.py (for tools/list) — drops tools not in profile allowlist
+filter.py (for tools/list) — drops tools not in profile allowlist; namespaces <backend>__<tool>
     │
     ▼
 Consumer
 ```
 
-### Why Starlette parent app
+The deprecated `/mcp` web-tools endpoint is still registered by FastMCP's
+`mcp.run()` but is not a consumer surface under Option C — airlock's tools are
+reached through the `internal://` backend above.
 
-FastMCP exposes `mcp.streamable_http_app()` returning a Starlette app. To add
-custom `/gateway/{profile}/mcp` routes we wrap that app inside a parent Starlette
-container that adds our routes at top-level priority and mounts the FastMCP app
-at `/` for everything else (so the existing `/mcp` web-tools endpoint keeps
-working unchanged).
+### Why custom_route, not a parent Starlette app
+
+Phase 1 originally planned a parent Starlette wrapper, but the gateway is wired
+via FastMCP's `custom_route("/gateway/{profile}/mcp")` decorator instead — it
+keeps FastMCP's internal routing intact and needs no app composition. Under
+Option C the gateway is the only live surface, so there is no parallel `/mcp`
+surface to preserve and no routing-collision concern.
 
 ### Why raw JSON-RPC instead of FastMCP-per-profile
 
@@ -141,21 +144,33 @@ auth check awkward, and complicates the future defense-pipeline injection point
 - [x] `tests/test_gateway_router.py`: method dispatch + tool routing with mocked `BackendPool`.
 - [x] `tests/test_gateway_app.py`: Starlette test-client integration.
 
-### Step 11: Quality gates
+### Step 11 (Option C): Internal-tool backend
 
-- [ ] `uv run ruff check src tests`
-- [ ] `uv run mypy src`
-- [ ] `uv run pytest -v`
+- [x] `gateway/profile.py`: `Backend.url` validator accepts `internal://<label>` (slug-validated) alongside `http(s)://`; add `Backend.is_internal` property.
+- [x] `gateway/internal.py`: module-level bound FastMCP server + `register_internal_server()`, `list_internal_tools()`, `call_internal_tool()` returning the same `dict` / `BackendCall` shapes as `backend.py` (reusing its `_serialize_tool` / `_serialize_content_block`).
+- [x] `gateway/router.py`: `_route_tools_list` and `_route_tools_call` dispatch on `backend.is_internal` (internal registry vs streamable-http). Namespacing and allowlist logic unchanged.
+- [x] `gateway/__init__.py`: export the internal-tool functions.
+- [x] `__init__.py` `_run_with_gateway()`: call `register_internal_server(mcp)` before `mcp.run(...)`.
+- [x] `tests/test_gateway_internal.py` + extend `tests/test_gateway_router.py` (mixed http+internal) and `tests/test_gateway_profile.py` (`internal://` validation).
+
+### Step 12: Quality gates
+
+- [x] `uv run ruff check src tests` (gateway + new tests clean)
+- [x] `uv run mypy src` (gateway clean)
+- [x] `uv run pytest -v` (332 passed, 32 pre-existing skips)
 - [ ] `gourmand --full .`
 - [ ] `podman build -f Containerfile .`
 
-### Step 12: Deploy to lotor
+### Step 13: Deploy to lotor (Option C cutover)
 
-- [ ] Push branch → GHA build → image at `quay.io/crunchtools/mcp-airlock:latest`
-- [ ] Provision `/srv/mcp-airlock.crunchtools.com/config/profiles.yaml` with `josui` + `kagetora` profiles
-- [ ] Add `AIRLOCK_GATEWAY_ENABLED=true` and `AIRLOCK_PROFILES_PATH=/etc/airlock/profiles.yaml` to env file
-- [ ] Mount profiles.yaml into container at /etc/airlock/profiles.yaml
-- [ ] systemctl restart, verify both endpoints respond, validate tool allowlist with a probe
+- [ ] Push branch → GHA build (or build the overlay image) → image carrying Option C
+- [ ] Provision `/srv/mcp-airlock.crunchtools.com/config/profiles.yaml` with real `josui` + `kagetora` profiles, each carrying the `web` (`internal://web`) backend + their http backend matrix
+- [ ] Generate `AIRLOCK_GATEWAY_JOSUI_TOKEN` + `AIRLOCK_GATEWAY_KAGETORA_TOKEN` on lotor (`secrets.token_hex(32)`), add to `mcp-airlock.env`
+- [ ] Add `AIRLOCK_GATEWAY_ENABLED=true` + `AIRLOCK_PROFILES_PATH=/etc/airlock/profiles.yaml`; mount profiles.yaml into the container
+- [ ] systemctl restart; verify `/gateway/<profile>/mcp` lists tools across an http backend AND `web__safe_fetch_tool`; confirm `/mcp` 404 is deliberate
+- [ ] **Cut Kagetora over first** (smaller blast radius, autonomous agent): one `mcp_servers:` entry in Hermes `config.yaml`; verify prompt-token count drops from ~146K toward <50K
+- [ ] **Then Josui**: one `airlock-gateway` entry in `~/.claude.json`; shrink the SSH tunnel from 10 LocalForwards to one (8019)
+- [ ] Clean up: delete the `gateway-test` profile, `/root/.airlock-gateway-test-token`, the `phase1` overlay image, and `Containerfile.gateway-overlay`
 
 ---
 
@@ -194,8 +209,9 @@ auth check awkward, and complicates the future defense-pipeline injection point
 
 | Risk | Impact | Mitigation |
 |------|--------|------------|
-| Backend MCP connection leaks under load | Med | `BackendPool` uses `async with` context managers; verified by mocked-client test that asserts on `__aexit__` calls. |
-| FastMCP's Starlette app conflicts with gateway routes | High | Mount FastMCP at `/` after gateway routes are registered — Starlette matches first-match-wins, so `/gateway/*` matches before `/`. Verified by integration test. |
+| Backend MCP connection leaks under load | Med | Phase 1 opens a fresh session per call (no pool); `async with` guarantees teardown. Pooling is a Phase 2 optimization. |
+| ~~FastMCP `/mcp` vs gateway custom-route collision (3.1.1)~~ | ~~High~~ | **Retired by Option C.** `/mcp` is deprecated and unused; its 404 on 3.1.1 is harmless. No fastmcp bump needed. |
+| Internal backend executing untrusted args in-process | Med | The internal backend only invokes airlock's own already-trusted tool coroutines, subject to the same per-profile allow/deny filter and call-time re-check as http backends. No new code path executes consumer content. |
 | Allowlist patterns allowing path traversal in tool names | Med | Glob validator rejects `..`, `/`, leading hyphen, regex metachars. Tested adversarially. |
 | Bearer tokens leaked in logs | High | Profile model uses `SecretStr`; errors.py scrubbed; mypy enforces no `__repr__` leak. Test asserts log absence. |
 | Profile YAML file not present on container start | Low | When `AIRLOCK_GATEWAY_ENABLED=true` but file missing → fail closed at startup with clear error log. When disabled → no profile load attempted. |
@@ -207,3 +223,4 @@ auth check awkward, and complicates the future defense-pipeline injection point
 | Date | Changes |
 |------|---------|
 | 2026-06-13 | Initial Phase 1 plan |
+| 2026-06-13 | Option C: internal-tool backend steps; routing-collision risk retired; migration step rewritten as the Kagetora-then-Josui single-endpoint cutover |

--- a/.specify/specs/006-gateway-mode/plan.md
+++ b/.specify/specs/006-gateway-mode/plan.md
@@ -1,0 +1,209 @@
+# Implementation Plan: Gateway Mode — Phase 1
+
+> **Spec ID:** 006-gateway-mode
+> **Status:** In Progress
+> **Last Updated:** 2026-06-13
+
+## Summary
+
+Phase 1: add a `gateway/` subpackage that exposes `/gateway/<profile>/mcp` endpoints
+alongside airlock's existing `/mcp` web-tools surface. Transparent proxy to
+backend MCP servers with bearer-token auth and tool-allowlist filtering on
+`tools/list` responses. No defense pipeline application yet — that's Phase 2.
+
+---
+
+## Architecture
+
+### Request Flow (Phase 1)
+
+```
+Consumer (Josui / Kagetora / future Takeda)
+    │
+    │  POST /gateway/<profile>/mcp   (Authorization: Bearer <token>)
+    │  Content-Type: application/json
+    │  Body: JSON-RPC 2.0 request
+    ▼
+Starlette parent app  (server.py)
+    │
+    │  route match on /gateway/{profile}/mcp
+    ▼
+gateway/app.py  GatewayHandler
+    │  ┌──────────────────┐
+    │  │ auth.py verify   │  bearer token vs profile config
+    │  ├──────────────────┤
+    │  │ profile lookup   │  loader.py registry
+    │  ├──────────────────┤
+    │  │ router.py        │  JSON-RPC method dispatch
+    │  │                  │
+    │  │  initialize ────────► return gateway server info
+    │  │  tools/list ────────► aggregate from backends, filter.py applies allowlist
+    │  │  tools/call ────────► backend.py routes to correct backend
+    │  │  ping ──────────────► return pong
+    │  │  (other) ───────────► method-not-found
+    │  └──────────────────┘
+    ▼
+backend.py
+    │  mcp.client.streamable_http connection pool (one per backend per profile)
+    ▼
+Backend MCP server (mcp-slack:8005, mcp-mediawiki:8016, etc.)
+    │
+    │  response
+    ▼
+filter.py (for tools/list) — drops tools not in profile allowlist
+    │
+    ▼
+Consumer
+```
+
+### Why Starlette parent app
+
+FastMCP exposes `mcp.streamable_http_app()` returning a Starlette app. To add
+custom `/gateway/{profile}/mcp` routes we wrap that app inside a parent Starlette
+container that adds our routes at top-level priority and mounts the FastMCP app
+at `/` for everything else (so the existing `/mcp` web-tools endpoint keeps
+working unchanged).
+
+### Why raw JSON-RPC instead of FastMCP-per-profile
+
+For Phase 1 transparency, raw JSON-RPC dispatch is simpler — we forward
+verbatim. Spinning up a FastMCP instance per profile with dynamically-registered
+proxy tools is feasible but adds initialization overhead, makes per-request
+auth check awkward, and complicates the future defense-pipeline injection point
+(Phase 2). Raw JSON-RPC keeps the chokepoint visible.
+
+---
+
+## Implementation Steps
+
+### Step 1: Add `pyyaml` dep + bump version
+
+- [x] `pyproject.toml`: add `pyyaml>=6.0`; bump `version = "0.4.0"`.
+
+### Step 2: Profile config models
+
+- [x] `gateway/profile.py`: Pydantic v2 models with `extra="forbid"` — `Profile`, `Backend`, `DefenseConfig`, `AuthConfig`.
+- [x] Bearer token typed as `SecretStr`, not in YAML.
+- [x] Allowlist/denylist as `list[str]` with restricted-glob validator (no regex metachars).
+
+### Step 3: YAML loader
+
+- [x] `gateway/loader.py`: `load_profiles(path: Path) -> dict[str, Profile]` using `yaml.safe_load`.
+- [x] Resolves `auth.bearer_token_env` → reads env var → constructs `SecretStr`.
+- [x] Raises `ProfileConfigError` on missing env vars (fail-closed at startup).
+- [x] Module-level `get_profile_registry()` for singleton access; lazy load on first call.
+
+### Step 4: Bearer-token auth
+
+- [x] `gateway/auth.py`: `verify_bearer(request, profile) -> None` raises `AuthError` on mismatch.
+- [x] Constant-time compare via `hmac.compare_digest`.
+- [x] Returns 401 with no token-content disclosure on failure.
+
+### Step 5: Backend connection management
+
+- [x] `gateway/backend.py`: `BackendPool` class managing `mcp.client.streamable_http` connections.
+- [x] Lazy connect on first call to a backend; cache the open session per profile+backend.
+- [x] `call_tool(profile, backend_name, tool_name, args) -> dict` for tools/call routing.
+- [x] `list_tools(profile, backend_name) -> list[dict]` for tools/list aggregation.
+- [x] Per-call timeout (from `Backend.timeout_seconds`, default 30).
+
+### Step 6: Allowlist filter
+
+- [x] `gateway/filter.py`: `filter_tools(tools: list[dict], allow: list[str], deny: list[str]) -> list[dict]`.
+- [x] Glob matching via `fnmatch.fnmatchcase` (already-validated restricted glob).
+- [x] Deny wins over allow.
+- [x] Tool names namespaced as `<backend>__<tool>` in the aggregated list.
+
+### Step 7: JSON-RPC router
+
+- [x] `gateway/router.py`: `route(profile, jsonrpc_request) -> jsonrpc_response`.
+- [x] Methods supported: `initialize`, `tools/list`, `tools/call`, `ping`.
+- [x] Other methods return JSON-RPC error `-32601` (method not found).
+- [x] Namespaced tool names parsed into `(backend, tool)` for routing.
+
+### Step 8: Starlette app
+
+- [x] `gateway/app.py`: `gateway_app(registry) -> Starlette` with route `POST /gateway/{profile}/mcp`.
+- [x] Phase 1 supports `POST` only; `GET`/`DELETE` for session management return 405 (defer to Phase 2).
+- [x] Auth handler runs before dispatch; 401 short-circuit.
+
+### Step 9: Mount in server.py
+
+- [x] Wrap existing `mcp.streamable_http_app()` in a parent Starlette app.
+- [x] Add gateway routes when `AIRLOCK_GATEWAY_ENABLED=true`.
+- [x] When env var unset/false: parent app is identical to old behavior (gateway routes absent).
+
+### Step 10: Tests
+
+- [x] `tests/test_gateway_profile.py`: profile loading happy path + 6 error cases.
+- [x] `tests/test_gateway_auth.py`: bearer-token cases.
+- [x] `tests/test_gateway_filter.py`: glob-pattern cases incl. deny override.
+- [x] `tests/test_gateway_router.py`: method dispatch + tool routing with mocked `BackendPool`.
+- [x] `tests/test_gateway_app.py`: Starlette test-client integration.
+
+### Step 11: Quality gates
+
+- [ ] `uv run ruff check src tests`
+- [ ] `uv run mypy src`
+- [ ] `uv run pytest -v`
+- [ ] `gourmand --full .`
+- [ ] `podman build -f Containerfile .`
+
+### Step 12: Deploy to lotor
+
+- [ ] Push branch → GHA build → image at `quay.io/crunchtools/mcp-airlock:latest`
+- [ ] Provision `/srv/mcp-airlock.crunchtools.com/config/profiles.yaml` with `josui` + `kagetora` profiles
+- [ ] Add `AIRLOCK_GATEWAY_ENABLED=true` and `AIRLOCK_PROFILES_PATH=/etc/airlock/profiles.yaml` to env file
+- [ ] Mount profiles.yaml into container at /etc/airlock/profiles.yaml
+- [ ] systemctl restart, verify both endpoints respond, validate tool allowlist with a probe
+
+---
+
+## File Changes
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `src/mcp_airlock_crunchtools/gateway/__init__.py` | Subpackage exports |
+| `src/mcp_airlock_crunchtools/gateway/profile.py` | Pydantic profile models |
+| `src/mcp_airlock_crunchtools/gateway/loader.py` | YAML loader + env resolution |
+| `src/mcp_airlock_crunchtools/gateway/auth.py` | Bearer-token check |
+| `src/mcp_airlock_crunchtools/gateway/backend.py` | Backend MCP connection pool |
+| `src/mcp_airlock_crunchtools/gateway/filter.py` | Tools/list allowlist filter |
+| `src/mcp_airlock_crunchtools/gateway/router.py` | JSON-RPC dispatch |
+| `src/mcp_airlock_crunchtools/gateway/app.py` | Starlette gateway app |
+| `src/mcp_airlock_crunchtools/gateway/errors.py` | Gateway error responses |
+| `tests/test_gateway_profile.py` | Profile + loader tests |
+| `tests/test_gateway_auth.py` | Auth tests |
+| `tests/test_gateway_filter.py` | Filter tests |
+| `tests/test_gateway_router.py` | Router tests |
+| `tests/test_gateway_app.py` | End-to-end integration tests |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `src/mcp_airlock_crunchtools/server.py` | Wrap FastMCP app in parent Starlette; mount gateway routes when enabled |
+| `src/mcp_airlock_crunchtools/config.py` | Add `AIRLOCK_GATEWAY_ENABLED`, `AIRLOCK_PROFILES_PATH` |
+| `pyproject.toml` | Add `pyyaml>=6.0`; bump `version` to `0.4.0` |
+
+---
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Backend MCP connection leaks under load | Med | `BackendPool` uses `async with` context managers; verified by mocked-client test that asserts on `__aexit__` calls. |
+| FastMCP's Starlette app conflicts with gateway routes | High | Mount FastMCP at `/` after gateway routes are registered — Starlette matches first-match-wins, so `/gateway/*` matches before `/`. Verified by integration test. |
+| Allowlist patterns allowing path traversal in tool names | Med | Glob validator rejects `..`, `/`, leading hyphen, regex metachars. Tested adversarially. |
+| Bearer tokens leaked in logs | High | Profile model uses `SecretStr`; errors.py scrubbed; mypy enforces no `__repr__` leak. Test asserts log absence. |
+| Profile YAML file not present on container start | Low | When `AIRLOCK_GATEWAY_ENABLED=true` but file missing → fail closed at startup with clear error log. When disabled → no profile load attempted. |
+
+---
+
+## Changelog
+
+| Date | Changes |
+|------|---------|
+| 2026-06-13 | Initial Phase 1 plan |

--- a/.specify/specs/006-gateway-mode/spec.md
+++ b/.specify/specs/006-gateway-mode/spec.md
@@ -2,37 +2,61 @@
 
 > **Spec ID:** 006-gateway-mode
 > **Status:** In Progress
-> **Version:** 0.1.0
+> **Version:** 0.2.0
 > **Author:** Scott McCarty
 > **Date:** 2026-06-13
 
 ## Overview
 
-Adds a per-consumer MCP gateway endpoint family (`POST /gateway/<profile>/mcp`)
-to airlock alongside the existing `/mcp` web-tools surface. Each profile defines
-which backend MCP servers a consumer can reach, which of their tools are
-allowed, and which defense layers (L1/L2/L3) apply to responses. Tool-allowlist
-filtering on `tools/list` responses gives **real prompt-context reduction** —
-unlike Claude Code's `permissions.deny` or Hermes's `disabled_tools`, both of
-which gate execution but still ship full tool definitions to the model.
+Makes the per-consumer MCP gateway endpoint family (`POST /gateway/<profile>/mcp`)
+the **single surface** for talking to airlock (Option C). Every tool a consumer
+can reach — airlock's own web/fetch tools *and* every backend MCP server on the
+`crunchtools` network — is surfaced through one per-consumer endpoint behind one
+bearer token. The profile is the policy: one endpoint, one token, one YAML stanza
+per agent.
 
-This spec covers **Phase 1** only: profile loader, bearer-token auth, endpoint
-routing, tool allowlist filter, transparent tools/call passthrough. Defense
-pipeline (L1/L2/L3 on responses), audit log integration, and Cockpit UI come
-in Phases 2-4. See `docs/gateway-design.md` for the full architecture and
-phasing.
+Airlock's native tools (`safe_fetch_tool`, `quarantine_fetch_tool`,
+`safe_search_tool`, …) are exposed as an **internal backend**: a profile backend
+whose URL uses the `internal://<label>` scheme dispatches in-process to airlock's
+own FastMCP tool registry instead of opening a streamable-http session. By
+convention this backend is named `web`, so the tools surface as
+`web__safe_fetch_tool`, `web__quarantine_fetch_tool`, etc. The result is that
+*every* tool response — whether from `safe_fetch` against the open web or from
+`mcp-atlassian` against a Confluence page — flows through the same gateway, and
+(from Phase 2) the same L1/L2/L3 defense pipeline.
+
+Tool-allowlist filtering on `tools/list` responses gives **real prompt-context
+reduction** — unlike Claude Code's `permissions.deny` or Hermes's
+`disabled_tools`, both of which gate execution but still ship full tool
+definitions to the model.
+
+The legacy `/mcp` web-tools surface is **deprecated** under Option C. It is still
+registered by FastMCP's `mcp.run(transport="streamable-http")` (and on the
+production base image, fastmcp 3.1.1, it returns 404 — see below), but no
+consumer should target it: airlock's tools are reachable through the gateway's
+`internal://` backend instead. Because `/mcp` and the gateway no longer need to
+coexist as live surfaces, the fastmcp 3.1.1 routing collision that constrained
+the earlier design is now irrelevant.
+
+This spec covers the gateway transport surface: profile loader, bearer-token
+auth, endpoint routing, tool allowlist filter, internal + http backend dispatch,
+transparent tools/call passthrough. Defense pipeline application (L1/L2/L3 on
+responses), audit log integration, and Cockpit UI come in later phases. See
+`docs/gateway-design.md` for the full architecture and phasing.
 
 ---
 
-## New Endpoints
+## Endpoints
 
-| Endpoint | Method | Description |
-|---|---|---|
-| `/gateway/<profile>/mcp` | POST, GET, DELETE | MCP streamable-http endpoint, one per consumer profile. Routes to the profile's configured backend MCP servers with tool-name allowlist filtering. |
+| Endpoint | Method | Status | Description |
+|---|---|---|---|
+| `/gateway/<profile>/mcp` | POST | **Canonical** | MCP endpoint, one per consumer profile. Routes to the profile's configured backends (http MCP servers + the `internal://` airlock-tools backend) with tool-name allowlist filtering. `GET`/`DELETE` return 405 (no session resumption). |
+| `/mcp` | POST | **Deprecated** | The original web-tools surface. Still registered by FastMCP but not for consumer use; airlock's tools are reached via the gateway's `internal://` backend. On the production base image (fastmcp 3.1.1) it returns 404 — deliberate, not a regression. |
 
-Not a "tool" in the MCP sense — a new HTTP endpoint family that itself exposes
-MCP protocol to consumers. `tools/list` returns the filtered union of backend
-tools; `tools/call` proxies to the appropriate backend.
+The gateway endpoint is not a "tool" in the MCP sense — it's an HTTP endpoint
+family that itself speaks MCP to consumers. `tools/list` returns the filtered,
+namespaced union of all backend tools (internal + http); `tools/call` dispatches
+to the appropriate backend.
 
 ---
 
@@ -50,6 +74,8 @@ tools; `tools/call` proxies to the appropriate backend.
 - Profile name in URL path validated against `^[a-z][a-z0-9-]*$` to prevent path traversal in route matching.
 
 ### Layer 3 — API Hardening
+- Backend URL scheme is scheme-discriminated: `http(s)://` for remote streamable-http MCP servers, `internal://<label>` for airlock's in-process tool registry. SSE and stdio are rejected at profile-load time. The `internal://` label must match `^[a-z][a-z0-9-]*$` so the namespace stays well-formed.
+- The internal backend executes airlock's own already-trusted tool coroutines in-process — no new network surface, no new credential. It is subject to the same per-profile allow/deny filter and call-time re-check as any http backend.
 - TLS for backend MCP connections when URL scheme is `https://` (loopback `http://` is fine on the `crunchtools` podman network).
 - Timeouts on all backend MCP calls (configurable per profile, default 30s).
 - Backend response size limit (configurable, default 10 MB; rejects oversized).
@@ -80,21 +106,24 @@ tools; `tools/call` proxies to the appropriate backend.
 | `gateway/auth.py` | Bearer-token verification (constant-time compare) |
 | `gateway/backend.py` | Backend MCP connection management via `mcp.client.streamable_http` |
 | `gateway/filter.py` | `tools/list` response allowlist filter (glob-pattern matching) |
-| `gateway/router.py` | JSON-RPC dispatch (`initialize`, `tools/list`, `tools/call`, `ping`) per profile |
+| `gateway/router.py` | JSON-RPC dispatch (`initialize`, `tools/list`, `tools/call`, `ping`) per profile; dispatches each backend by URL scheme (http vs internal) |
+| `gateway/internal.py` | Internal backend: walks airlock's own FastMCP tool registry, exposing `list_internal_tools()` / `call_internal_tool()` with the same return types as the http backend |
 | `gateway/app.py` | Starlette app exposing `/gateway/{profile}/mcp` routes |
 | `gateway/errors.py` | Gateway-specific error responses (constant-time auth fail, scrubbed messages) |
-| `tests/test_gateway_profile.py` | Profile model + loader tests |
+| `tests/test_gateway_profile.py` | Profile model + loader tests (incl. `internal://` scheme validation) |
 | `tests/test_gateway_auth.py` | Bearer-token verification tests |
 | `tests/test_gateway_filter.py` | Allowlist filter tests |
-| `tests/test_gateway_router.py` | JSON-RPC dispatch tests (mocked backend calls) |
+| `tests/test_gateway_router.py` | JSON-RPC dispatch tests, incl. mixed http+internal aggregation and internal-routed calls |
+| `tests/test_gateway_internal.py` | Internal-backend dispatch tests (list/call/error mapping + real-server smoke test) |
 
 ### Modified Files
 
 | File | Changes |
 |------|---------|
-| `server.py` | Mount gateway Starlette app alongside the FastMCP streamable-http app under a parent Starlette container |
+| `__init__.py` | `_run_with_gateway()`: when `AIRLOCK_GATEWAY_ENABLED=true`, register the gateway `custom_route` AND bind airlock's FastMCP server as the internal-tool backend (`register_internal_server`) before `mcp.run(...)` |
+| `gateway/profile.py` | `Backend.url` validator accepts `internal://<label>` alongside `http(s)://`; adds `Backend.is_internal` |
 | `config.py` | Add `AIRLOCK_GATEWAY_ENABLED`, `AIRLOCK_PROFILES_PATH` env vars |
-| `pyproject.toml` | Add `pyyaml>=6.0` to dependencies; bump version to 0.4.0 |
+| `pyproject.toml` | `pyyaml>=6.0` dependency; version bump |
 
 ---
 
@@ -126,25 +155,14 @@ Phase 1 adds zero `@mcp.tool()`-registered tools to the existing FastMCP surface
 
 1. **Should Phase 1 require `AIRLOCK_GATEWAY_ENABLED=true` to mount the routes?** Recommend yes — feature-flagged rollout, default off, no behavior change for existing deployments until flipped.
 2. **Profile reload behavior**: hot-reload on YAML file change (Phase 4 — Cockpit editor needs this), or restart-only for Phase 1? Recommend restart-only for Phase 1; revisit in Phase 4.
-3. **MCP `resources/*` and `prompts/*` methods**: deferred to v1.1 per design doc, not Phase 1. Phase 1 returns method-not-found for these.
+3. **MCP `resources/*` and `prompts/*` methods**: deferred to v1.1 per design doc. The gateway returns method-not-found for these for now.
 
-## Phase 1 known issues
-
-**FastMCP 3.1.1 / streamable-http custom-route collision** (deferred to Phase 1.1):
-On the current production base image (mcp-airlock:latest, fastmcp 3.1.1), registering
-the gateway's `custom_route("/gateway/{profile}/mcp")` causes the FastMCP-managed
-`/mcp` streamable-http endpoint to return HTTP 404 — both routes are present in
-`router.routes` after registration but only the custom route dispatches at runtime.
-Reproducible with the consolidated single-handler form; not yet reproduced on
-fastmcp 3.4.2 (local dev). Likely a routing-table compile-step bug in 3.1.1.
-
-Workaround for v1: production runs with `AIRLOCK_GATEWAY_ENABLED=false` (existing
-behavior); gateway architecture validation was performed on lotor with the overlay
-image and confirmed via `/gateway/gateway-test/mcp` returning a correctly-filtered
-5-tool list across two backends (mcp-slack, mcp-mediawiki) with the allowlist
-applied. Phase 1.1 work: bump fastmcp to 3.4.2+ in the canonical Containerfile,
-re-test the collision, replace `custom_route` with a Mount-based composition if
-the bug persists, then flip the production flag.
+> **Note on the fastmcp 3.1.1 routing collision (resolved by Option C):** the
+> earlier design worried that registering the gateway `custom_route` made the
+> FastMCP `/mcp` endpoint 404 on the production base image. Under Option C `/mcp`
+> is deprecated and unused, so its 404 is harmless — the collision no longer
+> constrains anything and the `AIRLOCK_GATEWAY_ENABLED` flag can be flipped on
+> without bumping fastmcp.
 
 ---
 
@@ -153,3 +171,4 @@ the bug persists, then flip the production flag.
 | Version | Date | Changes |
 |---------|------|---------|
 | 0.1.0 | 2026-06-13 | Initial draft — Phase 1 scope only |
+| 0.2.0 | 2026-06-13 | Option C: gateway is the single surface; `/mcp` deprecated; airlock's own tools exposed via the `internal://` backend; routing-collision known-issue retired. |

--- a/.specify/specs/006-gateway-mode/spec.md
+++ b/.specify/specs/006-gateway-mode/spec.md
@@ -1,0 +1,137 @@
+# Specification: Gateway Mode
+
+> **Spec ID:** 006-gateway-mode
+> **Status:** In Progress
+> **Version:** 0.1.0
+> **Author:** Scott McCarty
+> **Date:** 2026-06-13
+
+## Overview
+
+Adds a per-consumer MCP gateway endpoint family (`POST /gateway/<profile>/mcp`)
+to airlock alongside the existing `/mcp` web-tools surface. Each profile defines
+which backend MCP servers a consumer can reach, which of their tools are
+allowed, and which defense layers (L1/L2/L3) apply to responses. Tool-allowlist
+filtering on `tools/list` responses gives **real prompt-context reduction** —
+unlike Claude Code's `permissions.deny` or Hermes's `disabled_tools`, both of
+which gate execution but still ship full tool definitions to the model.
+
+This spec covers **Phase 1** only: profile loader, bearer-token auth, endpoint
+routing, tool allowlist filter, transparent tools/call passthrough. Defense
+pipeline (L1/L2/L3 on responses), audit log integration, and Cockpit UI come
+in Phases 2-4. See `docs/gateway-design.md` for the full architecture and
+phasing.
+
+---
+
+## New Endpoints
+
+| Endpoint | Method | Description |
+|---|---|---|
+| `/gateway/<profile>/mcp` | POST, GET, DELETE | MCP streamable-http endpoint, one per consumer profile. Routes to the profile's configured backend MCP servers with tool-name allowlist filtering. |
+
+Not a "tool" in the MCP sense — a new HTTP endpoint family that itself exposes
+MCP protocol to consumers. `tools/list` returns the filtered union of backend
+tools; `tools/call` proxies to the appropriate backend.
+
+---
+
+## Security Considerations
+
+### Layer 1 — Token Protection
+- Profile bearer tokens stored as `pydantic.SecretStr`.
+- Tokens read from env vars named in `auth.bearer_token_env` field of profile config — never hardcoded in YAML.
+- Token values scrubbed from all error messages (existing `errors.py` pattern extended to cover gateway errors).
+
+### Layer 2 — Input Validation
+- New Pydantic models for profile config in `gateway/profile.py` (`Profile`, `Backend`, `DefenseConfig`, `AuthConfig`), all with `extra="forbid"`.
+- Tool-name allowlist patterns validated as restricted glob (no regex, no shell metacharacters; only `*`, alphanumeric, underscore, hyphen).
+- Bearer tokens validated as non-empty constant-time-compared strings.
+- Profile name in URL path validated against `^[a-z][a-z0-9-]*$` to prevent path traversal in route matching.
+
+### Layer 3 — API Hardening
+- TLS for backend MCP connections when URL scheme is `https://` (loopback `http://` is fine on the `crunchtools` podman network).
+- Timeouts on all backend MCP calls (configurable per profile, default 30s).
+- Backend response size limit (configurable, default 10 MB; rejects oversized).
+- Failed backend connection emits 502 to consumer, never silently retries past N attempts.
+
+### Layer 4 — Dangerous Operation Prevention
+- Gateway code never executes user content — it's a transparent forwarder for Phase 1.
+- No shell execution, no `eval()`/`exec()`.
+- No filesystem writes from the gateway path (audit log writes come in Phase 3 via existing SQLite layer).
+- Profile YAML loaded with `yaml.safe_load` only (never `yaml.load`).
+
+### Layer 5 — Supply Chain Security
+- `pyyaml` added as direct dependency (was implicit via FastMCP); pinned to `>=6.0`.
+- `mcp` package already a transitive dep via `fastmcp>=2.0`; `mcp.client.streamable_http` reused for backend connections.
+- No new SDKs.
+
+---
+
+## Module Changes
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `gateway/__init__.py` | Subpackage exports |
+| `gateway/profile.py` | Pydantic models for profile config (`Profile`, `Backend`, `DefenseConfig`, `AuthConfig`) |
+| `gateway/loader.py` | YAML config loader with env-var token resolution |
+| `gateway/auth.py` | Bearer-token verification (constant-time compare) |
+| `gateway/backend.py` | Backend MCP connection management via `mcp.client.streamable_http` |
+| `gateway/filter.py` | `tools/list` response allowlist filter (glob-pattern matching) |
+| `gateway/router.py` | JSON-RPC dispatch (`initialize`, `tools/list`, `tools/call`, `ping`) per profile |
+| `gateway/app.py` | Starlette app exposing `/gateway/{profile}/mcp` routes |
+| `gateway/errors.py` | Gateway-specific error responses (constant-time auth fail, scrubbed messages) |
+| `tests/test_gateway_profile.py` | Profile model + loader tests |
+| `tests/test_gateway_auth.py` | Bearer-token verification tests |
+| `tests/test_gateway_filter.py` | Allowlist filter tests |
+| `tests/test_gateway_router.py` | JSON-RPC dispatch tests (mocked backend calls) |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `server.py` | Mount gateway Starlette app alongside the FastMCP streamable-http app under a parent Starlette container |
+| `config.py` | Add `AIRLOCK_GATEWAY_ENABLED`, `AIRLOCK_PROFILES_PATH` env vars |
+| `pyproject.toml` | Add `pyyaml>=6.0` to dependencies; bump version to 0.4.0 |
+
+---
+
+## Testing Requirements
+
+### Mocked Tests (no live MCP backends)
+
+- [ ] `TestProfileLoading` — valid YAML, missing tokens, bad allowlist patterns, schema violations.
+- [ ] `TestAuthVerification` — valid token, wrong token, missing header, malformed header, constant-time-compare verified by timing assertion sanity check.
+- [ ] `TestAllowlistFilter` — `*` wildcard, prefix glob, suffix glob, substring glob, multiple patterns, deny override.
+- [ ] `TestRouterDispatch` — `initialize` response, `tools/list` aggregation across mocked backends, `tools/call` routing to correct backend by namespaced tool name, `ping` response, unknown method 405.
+- [ ] `TestEndpointIntegration` — Starlette test client end-to-end: POST → auth check → dispatch → mocked backend → response.
+- [ ] Adversarial: profile name with `../`, allowlist pattern with regex metacharacters, oversized backend response.
+
+### Tool Count Update
+
+Phase 1 adds zero `@mcp.tool()`-registered tools to the existing FastMCP surface — the gateway endpoints are independent of the FastMCP tool registry. The `test_tool_count` assertion stays at its current value.
+
+---
+
+## Dependencies
+
+- Depends on: 005-safe-search (current head; no functional dependency, but ensures we're branching off the latest defense pipeline)
+- Blocks: 007 (gateway L1/L2/L3 defense application — Phase 2), 008 (gateway audit + Cockpit — Phase 3-4)
+
+---
+
+## Open Questions
+
+1. **Should Phase 1 require `AIRLOCK_GATEWAY_ENABLED=true` to mount the routes?** Recommend yes — feature-flagged rollout, default off, no behavior change for existing deployments until flipped.
+2. **Profile reload behavior**: hot-reload on YAML file change (Phase 4 — Cockpit editor needs this), or restart-only for Phase 1? Recommend restart-only for Phase 1; revisit in Phase 4.
+3. **MCP `resources/*` and `prompts/*` methods**: deferred to v1.1 per design doc, not Phase 1. Phase 1 returns method-not-found for these.
+
+---
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 0.1.0 | 2026-06-13 | Initial draft — Phase 1 scope only |

--- a/.specify/specs/006-gateway-mode/spec.md
+++ b/.specify/specs/006-gateway-mode/spec.md
@@ -128,6 +128,24 @@ Phase 1 adds zero `@mcp.tool()`-registered tools to the existing FastMCP surface
 2. **Profile reload behavior**: hot-reload on YAML file change (Phase 4 — Cockpit editor needs this), or restart-only for Phase 1? Recommend restart-only for Phase 1; revisit in Phase 4.
 3. **MCP `resources/*` and `prompts/*` methods**: deferred to v1.1 per design doc, not Phase 1. Phase 1 returns method-not-found for these.
 
+## Phase 1 known issues
+
+**FastMCP 3.1.1 / streamable-http custom-route collision** (deferred to Phase 1.1):
+On the current production base image (mcp-airlock:latest, fastmcp 3.1.1), registering
+the gateway's `custom_route("/gateway/{profile}/mcp")` causes the FastMCP-managed
+`/mcp` streamable-http endpoint to return HTTP 404 — both routes are present in
+`router.routes` after registration but only the custom route dispatches at runtime.
+Reproducible with the consolidated single-handler form; not yet reproduced on
+fastmcp 3.4.2 (local dev). Likely a routing-table compile-step bug in 3.1.1.
+
+Workaround for v1: production runs with `AIRLOCK_GATEWAY_ENABLED=false` (existing
+behavior); gateway architecture validation was performed on lotor with the overlay
+image and confirmed via `/gateway/gateway-test/mcp` returning a correctly-filtered
+5-tool list across two backends (mcp-slack, mcp-mediawiki) with the allowlist
+applied. Phase 1.1 work: bump fastmcp to 3.4.2+ in the canonical Containerfile,
+re-test the collision, replace `custom_route` with a Mount-based composition if
+the bug persists, then flip the production flag.
+
 ---
 
 ## Changelog

--- a/Containerfile
+++ b/Containerfile
@@ -51,9 +51,22 @@ RUN HF_TOKEN="${HF_TOKEN}" python -m optimum.exporters.onnx \
       /models/prompt-guard-2-22m/
 
 # ============================================================
-# Stage 2: Runtime image (ONNX Runtime only — no PyTorch)
-# Hummingbird Python is minimal — libstdc++ copied from builder
-# to support onnxruntime/numpy C extensions at runtime.
+# Stage 2: pip install (builder variant — has shell for RUN)
+# Hummingbird default is distroless (no /bin/sh), so pip install
+# must happen in a builder stage. Installed packages are copied
+# into the final distroless image.
+# ============================================================
+FROM quay.io/hummingbird/python:latest-builder AS pip-builder
+USER 0
+
+WORKDIR /app
+COPY pyproject.toml README.md ./
+COPY src/ ./src/
+
+RUN pip install --no-cache-dir --prefix=/usr .
+
+# ============================================================
+# Stage 3: Runtime image (distroless — no shell, no dnf)
 # ============================================================
 FROM quay.io/hummingbird/python:latest
 
@@ -74,19 +87,15 @@ LABEL name="mcp-airlock-crunchtools" \
 
 WORKDIR /app
 
-# Copy libstdc++ from builder — required by onnxruntime/numpy C extensions
+# Copy libstdc++ from model-builder — required by onnxruntime/numpy C extensions
 COPY --from=model-builder /usr/lib64/libstdc++.so.6* /usr/lib64/
 
-# Copy ONNX model files from builder stage (no PyTorch in final image)
+# Copy ONNX model files from model-builder (no PyTorch in final image)
 COPY --from=model-builder /models/prompt-guard-2-22m/ /models/prompt-guard-2-22m/
 
-COPY pyproject.toml README.md ./
-COPY src/ ./src/
-
-RUN pip install --no-cache-dir .
-
-RUN python -c "from mcp_airlock_crunchtools import main; print('Installation verified')" && \
-    python -c "from mcp_airlock_crunchtools.quarantine.classifier import is_classifier_available; assert is_classifier_available(), 'Classifier failed to load'; print('Classifier verified')"
+# Copy installed Python packages from pip-builder (pure Python + native C extensions)
+COPY --from=pip-builder /usr/lib/python3.14/site-packages/ /usr/lib/python3.14/site-packages/
+COPY --from=pip-builder /usr/lib64/python3.14/site-packages/ /usr/lib64/python3.14/site-packages/
 
 ENV QUARANTINE_DB=/data/quarantine.db
 ENV CLASSIFIER_MODEL_PATH=/models/prompt-guard-2-22m

--- a/Containerfile
+++ b/Containerfile
@@ -58,7 +58,7 @@ RUN HF_TOKEN="${HF_TOKEN}" python -m optimum.exporters.onnx \
 FROM quay.io/hummingbird/python:latest
 
 LABEL name="mcp-airlock-crunchtools" \
-      version="0.2.2" \
+      version="0.4.0" \
       summary="Secure MCP server for quarantined web content extraction" \
       description="Three-layer defense against prompt injection: deterministic sanitization + Prompt Guard 2 classifier + quarantined LLM" \
       maintainer="crunchtools.com" \

--- a/Containerfile.gateway-overlay
+++ b/Containerfile.gateway-overlay
@@ -1,0 +1,23 @@
+# Local-only overlay Containerfile for Phase 1 gateway deployment.
+#
+# Builds on top of the existing production airlock image and overlays the
+# new gateway source code. starlette, uvicorn, and pyyaml are already
+# in the base image — no pip install needed.
+#
+# Used as a temporary workaround while the canonical container.yml build
+# is blocked on an upstream HF gated-repo access issue.
+#
+# Build locally:
+#   podman build -f Containerfile.gateway-overlay -t mcp-airlock-gateway-overlay .
+# Then save + load on lotor for the Phase 1 architecture validation.
+
+FROM quay.io/crunchtools/mcp-airlock:latest
+
+USER 0
+
+COPY src/mcp_airlock_crunchtools/__init__.py /tmp/.local/lib/python3.14/site-packages/mcp_airlock_crunchtools/__init__.py
+COPY src/mcp_airlock_crunchtools/gateway /tmp/.local/lib/python3.14/site-packages/mcp_airlock_crunchtools/gateway
+
+USER 65532
+
+LABEL org.opencontainers.image.description="Phase 1 gateway overlay (not for registry push)"

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -1,8 +1,8 @@
 # Gateway Mode — airlock as the trusted boundary for MCP traffic
 
-**Status:** Design draft (v0.1) — open for review
+**Status:** Design draft (v0.2, Option C — single-endpoint architecture)
 **Branch:** `feat/gateway-design`
-**Tracking task:** crunchtools/tmp #18
+**Tracking task:** crunchtools/tmp #18 · RT #1438 (Option C)
 
 ---
 
@@ -65,10 +65,17 @@ Three problems converge:
 
 ## Approach
 
-Add a second endpoint family to airlock alongside the existing `/mcp`:
+> **Option C (2026-06-13):** the gateway is the **single** surface. The original
+> `/mcp` web-tools endpoint is deprecated — airlock's own tools are folded into
+> the gateway as an in-process `internal://` backend (conventionally named `web`),
+> so one per-consumer endpoint behind one bearer token covers airlock's tools
+> *and* the whole MCP fleet. There is no parallel surface to maintain.
+
+The gateway endpoint family:
 
 ```
-POST /gateway/<profile_name>/mcp
+POST /gateway/<profile_name>/mcp        ← canonical, single surface
+POST /mcp                                ← deprecated (404 on the fastmcp 3.1.1 base)
 ```
 
 Each request to the gateway endpoint:
@@ -76,9 +83,11 @@ Each request to the gateway endpoint:
 1. **Authenticates** the caller (bearer token in `Authorization` header, matched
    against the profile's configured token).
 2. **Resolves** the consumer's profile (tool allowlist + defense config).
-3. **Proxies** the MCP call to the relevant backend MCP server via the
-   `crunchtools` podman network (container DNS lookup — already how Kagetora
-   reaches the fleet today).
+3. **Dispatches** the MCP call by backend URL scheme: `http(s)://` proxies to a
+   remote MCP server via the `crunchtools` podman network (container DNS lookup
+   — already how Kagetora reaches the fleet today); `internal://<label>`
+   dispatches in-process to airlock's own FastMCP tool registry. Both paths
+   return identical wire shapes to the consumer.
 4. **On `tools/list` response:** drops tool definitions not in the profile's
    allowlist *before* forwarding to the consumer. This is where context savings
    come from.
@@ -89,9 +98,9 @@ Each request to the gateway endpoint:
    counts) to airlock's existing SQLite audit table.
 7. **Surfaces** in the Cockpit plugin under a new "Gateway" tab.
 
-The existing `/mcp` endpoint with the 6 web-content tools stays exactly as-is
-for backwards compatibility. A `default` profile in config can also be exposed
-at `/mcp` to give the airlock tools the same gateway treatment if desired.
+Under Option C the standalone `/mcp` web-tools endpoint is deprecated; airlock's
+own tools are reached through the gateway's `internal://` backend, so every tool
+response — web fetches included — flows through the single gateway chokepoint.
 
 ---
 
@@ -104,8 +113,12 @@ on file change (handled by Cockpit when profiles are edited from the UI).
 profiles:
   josui:
     auth:
-      bearer_token_env: AIRLOCK_PROFILE_JOSUI_TOKEN
+      bearer_token_env: AIRLOCK_GATEWAY_JOSUI_TOKEN
     backends:
+      web:                              # airlock's own tools, in-process
+        url: internal://web
+        tools_allow: ["*"]
+        tools_deny: []
       mcp-slack:
         url: http://mcp-slack:8005/mcp
         tools_allow: ["*"]
@@ -181,10 +194,13 @@ profiles:
 
 ### Consumer-visible tool names
 
-Backend tools are exposed under their original names, namespaced by server name
-to avoid collisions:
+Backend tools are exposed under their original names, namespaced by backend name
+to avoid collisions — including airlock's own tools under the `internal://`
+backend's name (conventionally `web`):
 
 ```
+web__safe_fetch_tool
+web__quarantine_fetch_tool
 mcp-slack__slack_list_channels
 mcp-atlassian__jira_search
 google-workspace-personal__get_gmail_message_content
@@ -280,25 +296,39 @@ update SQLite and the YAML file with locking.
 
 ## Migration & compatibility
 
-The existing `/mcp` endpoint stays. Two migration paths for current consumers:
+Option C is a **hard cut on the airlock side** (the gateway is the only surface),
+with consumers migrating at their own pace. Each consumer collapses its many MCP
+entries — including the old direct airlock `/mcp` entry — into a single
+gateway entry behind one bearer token. **Kagetora cuts over first** (smaller
+blast radius, autonomous agent), then Josui.
 
-**Josui (Claude Code on Breetai):**
-1. Add `josui` profile to airlock config with all 14 backends + Josui's deny list.
-2. Replace the 12 `LocalForward` lines in `~/.ssh/config` with one (to airlock's port).
-3. Replace 12 `~/.claude.json` MCP entries with one entry pointing at
-   `http://127.0.0.1:8019/gateway/josui/mcp`.
-4. Confirm all tools still work; the existing direct connections to airlock's
-   `/mcp` (web tools) continue to coexist.
+**Kagetora (Hermes on lotor) — first:**
+1. Add the `kagetora` profile to airlock config: the `web` (`internal://web`)
+   backend + a narrowed http backend set.
+2. Replace the 14 `mcp_servers:` entries in Hermes `config.yaml` with one
+   `airlock-gateway` entry pointing at
+   `http://mcp-airlock:8019/gateway/kagetora/mcp` (Bearer
+   `${AIRLOCK_GATEWAY_KAGETORA_TOKEN}`).
+3. Restart kagetora; verify a call exercises both an http backend
+   (`mcp-gemini__gemini_query_tool`) and the internal backend
+   (`web__safe_fetch_tool`); confirm the prompt-token count drops from ~146K
+   toward the <50K target.
 
-**Kagetora (Hermes on lotor):**
-1. Add `kagetora` profile to airlock config with a narrower backend set.
-2. Replace the 14 `mcp_servers:` entries in Hermes `config.yaml` with one entry
-   pointing at `http://mcp-airlock:8019/gateway/kagetora/mcp`.
-3. Restart kagetora; verify reduced prompt token count.
+**Josui (Claude Code on Breetai) — second:**
+1. Add the `josui` profile with the `web` backend + the full http backend matrix.
+2. Replace the ~10 migrated `~/.claude.json` MCP entries + the old airlock entry
+   with one `airlock-gateway` entry pointing at
+   `http://127.0.0.1:8019/gateway/josui/mcp`. Genuinely-local servers (pcloud,
+   trove, claude-in-chrome, …) stay as-is.
+3. Shrink the `~/.ssh/config` `lotor-mcp` tunnel from 10 `LocalForward` lines to
+   one (8019).
+4. Confirm `web__safe_fetch_tool` returns sanitized content and a remote backend
+   (`mcp-slack__slack_list_channels`) returns results — both via the same token,
+   single endpoint.
 
-Estimated context savings for Kagetora when narrowed to (memory, airlock,
-mcp-gemini, google-workspace-personal): ~575 tools → ~150 tools, ~137K → ~35K
-prompt tokens, ~75% reduction.
+Estimated context savings for Kagetora when narrowed to (web, memory,
+mcp-gemini, google-workspace-personal): ~575 tools → ~150 tools, ~146K → <50K
+prompt tokens.
 
 ---
 
@@ -417,6 +447,7 @@ they arrive, applying L1 incrementally; L2/L3 buffer until the stream completes
 | Phase | Scope | Estimated effort |
 |---|---|---|
 | 1 | Profile loader + auth + endpoint routing + tool allowlist filter (no defense pipeline yet) | ~half session |
+| 1-final (Option C) | `internal://` airlock-tools backend; `/mcp` deprecated; gateway becomes the single surface | ~half session |
 | 2 | L1 + L2 on tool-call responses; L3 with profile + Cockpit master switch | ~half session |
 | 3 | Audit log integration + Cockpit Gateway tab (read-only) | ~half session |
 | 4 | Cockpit profile editor + token rotation UI | ~half session |

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -1,0 +1,436 @@
+# Gateway Mode — airlock as the trusted boundary for MCP traffic
+
+**Status:** Design draft (v0.1) — open for review
+**Branch:** `feat/gateway-design`
+**Tracking task:** crunchtools/tmp #18
+
+---
+
+## Summary
+
+Airlock today exposes 6 web-content tools (`fetch`, `read`, `search`, `scan`,
+`blocklist`, `stats`) that run untrusted content through a 3-layer prompt-injection
+defense (L1 sanitize → L2 Prompt Guard 2 classifier → L3 quarantined Gemini
+re-extraction) before returning anything to the LLM.
+
+This design extends airlock with a second surface — a **per-consumer MCP gateway**
+that proxies traffic to the 14 backend MCP servers running on lotor, applying the
+same defense pipeline to every tool response on the way back, with per-profile
+control of which tools each consumer sees and which defense layers run.
+
+Net result: one chokepoint, one audit log, one Cockpit UI, one policy plane
+covering both web fetches *and* MCP-server tool outputs.
+
+---
+
+## Mission restatement
+
+Airlock's mission has always been the **trusted boundary between untrusted content
+and the LLM**. Web-fetch happens to be the only surface currently implemented because
+the LLM platforms Scott uses (Claude, Gemini) ship web search/fetch as native tools
+and don't route them through MCP — so airlock had to provide replacement tools.
+
+Every MCP server that returns content is the same threat: a wiki page, an RT ticket
+comment, a Slack message thread, a Jira issue description, a Confluence page, an
+email body — every one is a channel an attacker can plant prompt-injection payloads
+in. None of them currently flow through airlock. The gateway extension closes that
+gap without changing the mission.
+
+---
+
+## Problem
+
+Three problems converge:
+
+1. **MCP responses bypass airlock.** A malicious Confluence page, a Jira ticket
+   description written by a hostile user, a phishing email rendered through the
+   Gmail MCP — every one of those reaches the LLM unfiltered today. Airlock is
+   the right boundary for this content but has no current path to it.
+
+2. **Per-consumer policy lives in two places.** Josui's deny list lives in
+   `~/.claude/settings.json`. Kagetora's deny list lives in Hermes's
+   `config.yaml`. The patterns are identical (`delete_*`, `send_gmail_message`,
+   `wordpress_delete_*`, etc.) but expressed differently, maintained
+   separately, and the next consumer (Takeda/OpenClaw) would make it a third
+   place to update. The policy plane wants centralization.
+
+3. **Tool-definition context pollution.** The MCP fleet exposes ~575 tools,
+   summing to ~137,000 prompt tokens of tool descriptions per turn. Per-consumer
+   deny lists (Claude Code's `permissions.deny`, Hermes's `disabled_tools`) gate
+   *execution* but the tool definitions still ship in every prompt. Filtering
+   them at the `tools/list` response — *before* they reach the consumer — is
+   the only mechanism that actually reduces context cost.
+
+---
+
+## Approach
+
+Add a second endpoint family to airlock alongside the existing `/mcp`:
+
+```
+POST /gateway/<profile_name>/mcp
+```
+
+Each request to the gateway endpoint:
+
+1. **Authenticates** the caller (bearer token in `Authorization` header, matched
+   against the profile's configured token).
+2. **Resolves** the consumer's profile (tool allowlist + defense config).
+3. **Proxies** the MCP call to the relevant backend MCP server via the
+   `crunchtools` podman network (container DNS lookup — already how Kagetora
+   reaches the fleet today).
+4. **On `tools/list` response:** drops tool definitions not in the profile's
+   allowlist *before* forwarding to the consumer. This is where context savings
+   come from.
+5. **On `tools/call` response:** runs the response content through the configured
+   defense layers (L1 always; L2 always; L3 optional per-profile) and returns
+   sanitized content + detection metadata to the consumer.
+6. **Audits** every passthrough (profile, backend, tool, detection scores, byte
+   counts) to airlock's existing SQLite audit table.
+7. **Surfaces** in the Cockpit plugin under a new "Gateway" tab.
+
+The existing `/mcp` endpoint with the 6 web-content tools stays exactly as-is
+for backwards compatibility. A `default` profile in config can also be exposed
+at `/mcp` to give the airlock tools the same gateway treatment if desired.
+
+---
+
+## Profile schema
+
+YAML in `/etc/airlock/profiles.yaml` (or `$AIRLOCK_PROFILES_PATH`), hot-reloaded
+on file change (handled by Cockpit when profiles are edited from the UI).
+
+```yaml
+profiles:
+  josui:
+    auth:
+      bearer_token_env: AIRLOCK_PROFILE_JOSUI_TOKEN
+    backends:
+      mcp-slack:
+        url: http://mcp-slack:8005/mcp
+        tools_allow: ["*"]
+        tools_deny: []
+      mcp-mediawiki:
+        url: http://mcp-mediawiki:8016/mcp
+        tools_allow: ["*"]
+        tools_deny: []
+      mcp-atlassian:
+        url: http://mcp-atlassian:8021/mcp
+        tools_allow: ["*"]
+        tools_deny: ["jira_delete_issue"]
+      mcp-wordpress-crunchtools:
+        url: http://mcp-wordpress-crunchtools:8002/mcp
+        tools_allow: ["*"]
+        tools_deny:
+          - "wordpress_delete_post"
+          - "wordpress_delete_page"
+          - "wordpress_delete_media"
+          - "wordpress_delete_comment"
+      google-workspace-personal:
+        url: http://google-workspace-personal:8000/mcp
+        tools_allow: ["*"]
+        tools_deny:
+          - "send_gmail_message"
+          - "delete*"
+          - "batch_delete*"
+      # ... rest of Josui's backends
+    defense:
+      sanitize: true                # L1 — always cheap, default on
+      classify: true                # L2 — Prompt Guard 2 inference
+      classify_threshold: 0.5
+      quarantine: true              # L3 — Gemini re-extraction
+      quarantine_threshold: 0.7
+      audit: true
+
+  kagetora:
+    auth:
+      bearer_token_env: AIRLOCK_PROFILE_KAGETORA_TOKEN
+    backends:
+      memory:
+        url: http://mcp-memory:8765/mcp
+        tools_allow: ["*"]
+        tools_deny: []
+        headers:
+          Authorization: "Bearer ${MCP_MEMORY_API_KEY}"
+      mcp-gemini:
+        url: http://mcp-gemini:8006/mcp
+        tools_allow: ["*"]
+        tools_deny: ["gemini_delete_cache_tool"]
+      google-workspace-personal:
+        url: http://google-workspace-personal:8000/mcp
+        tools_allow: ["search_gmail_messages", "get_gmail_*", "list_calendars", "get_events", "manage_event"]
+        tools_deny: ["send_gmail_message", "delete*"]
+      # ... narrower backend set
+    defense:
+      sanitize: true
+      classify: true
+      classify_threshold: 0.3       # more aggressive for autonomous agent
+      quarantine: false             # L3 OFF — token-cost-sensitive (see §"L3 toggle")
+      audit: true
+```
+
+### Allowlist semantics
+
+- `tools_allow` supports `*` (all), exact names, and `prefix*` / `*suffix` /
+  `*substring*` globs.
+- `tools_deny` runs after `tools_allow` and wins on conflict.
+- A tool is exposed to the consumer iff it matches `tools_allow` AND doesn't
+  match `tools_deny`.
+- The check runs against the *backend's* tool name (not the namespaced
+  consumer-visible name).
+
+### Consumer-visible tool names
+
+Backend tools are exposed under their original names, namespaced by server name
+to avoid collisions:
+
+```
+mcp-slack__slack_list_channels
+mcp-atlassian__jira_search
+google-workspace-personal__get_gmail_message_content
+```
+
+Matches the `mcp__<server>__<tool>` convention Claude Code already uses, and
+Hermes accepts namespaced tool names natively.
+
+---
+
+## L3 toggle (token-cost control)
+
+L3 (Q-Agent / quarantined Gemini re-extraction) is the only defense layer with a
+non-trivial token cost — every L3-triggered call burns Gemini tokens for
+re-extraction. Two controls:
+
+1. **Per-profile static toggle**: `defense.quarantine: false` disables L3 for
+   that profile entirely. L2 still runs and flags suspicious content in the
+   audit log, but the response passes through to the consumer with a detection
+   metadata sidecar instead of being re-extracted.
+
+2. **Cockpit runtime override**: a global "L3 enabled" switch in the Cockpit
+   backend, persisted to airlock's SQLite settings table, takes precedence over
+   per-profile config. Lets Scott kill L3 fleet-wide during a Gemini outage or
+   when chasing a quota issue without redeploying.
+
+When L3 is disabled (either path), the response still carries the L1/L2
+detection metadata sidecar so the consumer agent can decide whether to trust
+or discard.
+
+---
+
+## Integration with existing 3-layer defense
+
+| Layer | Reuse | New |
+|---|---|---|
+| L1 — sanitize | Existing `sanitize/` pipeline applied to MCP response content | None |
+| L2 — Prompt Guard 2 | Existing classifier, same thresholds (per-profile-configurable) | None |
+| L3 — Q-Agent | Existing quarantined Gemini path with `quarantine_threshold` trigger | Per-profile + runtime toggle |
+| Audit | Existing SQLite events table; add `gateway_passthrough` row type | New columns: `profile`, `backend`, `tool` |
+| P-Agent (policy) | Existing blocklist logic applies to backend MCP servers (block a backend if its responses keep tripping L2) | New: blocklist scope expands from URL to MCP-server URL |
+
+The defense pipeline is mostly reused verbatim — what's new is the wrapper that
+turns "fetched web content" into "MCP tool-call response content" and routes it
+through. ~200 lines of FastMCP server code + ~100 lines of profile loader +
+~100 lines of audit-log adapter.
+
+---
+
+## Auth model
+
+**v1**: bearer token per profile. Token value read from the env var named in
+`auth.bearer_token_env`. Consumer sends `Authorization: Bearer <token>`.
+
+**Out of scope for v1**: OAuth 2.0, OIDC, per-user-within-profile. FastMCP's auth
+middleware makes these clean v2 additions.
+
+Tokens never appear in config files (only env var names do); env file lives at
+`/srv/mcp-airlock.crunchtools.com/config/profile-tokens.env` with chmod 600 +
+chcon etc_t per the crunchtools convention.
+
+---
+
+## Audit & Cockpit additions
+
+Every gateway passthrough writes one row to airlock's SQLite audit table:
+
+| Column | Type | Example |
+|---|---|---|
+| ts | datetime | 2026-06-13T10:42:11Z |
+| profile | text | josui |
+| backend | text | mcp-atlassian |
+| tool | text | jira_search |
+| op | text | tools/call \| tools/list |
+| l1_score | real | 0.02 |
+| l2_score | real | 0.71 |
+| l3_triggered | bool | true |
+| resp_bytes | int | 41882 |
+| latency_ms | int | 2340 |
+
+New Cockpit panel **Gateway**:
+- **Top-N tools per profile (last 24h)** — informs allowlist tuning
+- **Detection events timeline** — every L2 flag and L3 trigger, with drill-down to the response that tripped it
+- **Profile editor** — read-write YAML editor with validation, writes back to `/etc/airlock/profiles.yaml`
+- **L3 master switch** — global on/off toggle (token-cost control)
+- **Real-time passthrough tail** — live view of in-flight gateway calls
+
+The Cockpit plugin uses airlock's existing D-Bus interface for read access;
+write paths (profile editor, L3 switch) go through new D-Bus methods that
+update SQLite and the YAML file with locking.
+
+---
+
+## Migration & compatibility
+
+The existing `/mcp` endpoint stays. Two migration paths for current consumers:
+
+**Josui (Claude Code on Breetai):**
+1. Add `josui` profile to airlock config with all 14 backends + Josui's deny list.
+2. Replace the 12 `LocalForward` lines in `~/.ssh/config` with one (to airlock's port).
+3. Replace 12 `~/.claude.json` MCP entries with one entry pointing at
+   `http://127.0.0.1:8019/gateway/josui/mcp`.
+4. Confirm all tools still work; the existing direct connections to airlock's
+   `/mcp` (web tools) continue to coexist.
+
+**Kagetora (Hermes on lotor):**
+1. Add `kagetora` profile to airlock config with a narrower backend set.
+2. Replace the 14 `mcp_servers:` entries in Hermes `config.yaml` with one entry
+   pointing at `http://mcp-airlock:8019/gateway/kagetora/mcp`.
+3. Restart kagetora; verify reduced prompt token count.
+
+Estimated context savings for Kagetora when narrowed to (memory, airlock,
+mcp-gemini, google-workspace-personal): ~575 tools → ~150 tools, ~137K → ~35K
+prompt tokens, ~75% reduction.
+
+---
+
+## Deployment (lotor)
+
+Same `/srv/mcp-airlock.crunchtools.com/` layout the airlock service already
+uses on lotor. Adds:
+
+- `/srv/mcp-airlock.crunchtools.com/config/profiles.yaml` — profile definitions
+- `/srv/mcp-airlock.crunchtools.com/config/profile-tokens.env` — bearer tokens
+  (chmod 600, chcon etc_t, env-file passed to systemd unit)
+- `/srv/mcp-airlock.crunchtools.com/data/audit.db` — already exists for L1/L2/L3
+  events; gains gateway-passthrough rows
+- Cockpit plugin gains the Gateway tab — same `cockpit-airlock/` package, lives
+  in `/usr/share/cockpit/airlock/`
+
+No new container, no new port, no new systemd unit. The existing
+`mcp-airlock.crunchtools.com.service` stays as-is; the airlock binary gains a
+new endpoint family on its existing `127.0.0.1:8019` listener.
+
+Cockpit visualization comes free with the existing Cockpit instance on lotor —
+the Gateway tab appears alongside the current Airlock tab on first login after
+the image bumps.
+
+---
+
+## Cascade integration
+
+mcp-airlock is already in the cascade (FROM-graph parent: the Hummingbird Python
+3.13 base; dispatch fanout already covers it). The version bump for this work
+goes through the existing build pipeline:
+
+- Buildah → Trivy (HIGH/CRITICAL block) → SBOM → Quay + GHCR push
+- Parent-image-updated dispatches still fire on Hummingbird rebuilds
+- No `schedule:` trigger
+- SemVer bump: MINOR (0.3.0 → 0.4.0) — backwards-compatible addition
+
+---
+
+## Performance considerations
+
+Per gateway call (worst case, L3 triggered):
+
+| Step | Latency |
+|---|---|
+| Auth check + profile lookup | <1ms |
+| Backend MCP call (over `crunchtools` network) | depends on backend (5-500ms typical) |
+| L1 sanitization | <10ms |
+| L2 classifier | 50-200ms (Prompt Guard 2 inference) |
+| L3 quarantine (if triggered) | 1-2s (Gemini round-trip) |
+| Audit log write | <5ms |
+
+L3-off case (per profile): drops the 1-2s tail. L3 only fires when L2 > threshold,
+so in steady state L3 contributes near-zero latency.
+
+`tools/list` response (allowlist filter only, no content scan): <5ms overhead.
+
+Streaming preserved end-to-end for SSE responses — airlock forwards chunks as
+they arrive, applying L1 incrementally; L2/L3 buffer until the stream completes
+(or until a watermark, configurable).
+
+---
+
+## Security considerations
+
+- **Fail-closed defaults**: profile not found → 404; auth missing → 401; backend
+  unreachable → 502 with retry-after; L2 classifier unavailable → fail-closed
+  (response held, error returned to consumer) unless profile sets
+  `defense.classify_fallback: allow`.
+- **Token rotation**: tokens are env-file-loaded; rotation = update env file +
+  systemd reload (no rebuild).
+- **Server-to-server trust**: backends are trusted on the `crunchtools` network
+  (loopback-bind only, no public reach). Airlock is the only thing talking to
+  them through this path.
+- **Audit immutability**: SQLite audit table is append-only (existing pattern);
+  Cockpit shows but never edits.
+- **Cockpit auth**: existing Cockpit auth (RHEL system auth) gates UI access.
+  Profile-editor write access requires the existing `cockpit-airlock-admin`
+  role.
+
+---
+
+## Non-goals / out of scope (v1)
+
+- OIDC / OAuth (v2)
+- Rate limiting (v2 — could fold into airlock's existing P-Agent blocklist)
+- Caching backend responses (v2 — backends own their own caching)
+- MCP resources / prompts passthrough — v1 covers `tools/list` and `tools/call`
+  only; `resources/list`, `resources/read`, `prompts/list`, `prompts/get` come
+  in v1.1 (mechanically similar to tools)
+- Cross-profile aggregation (one consumer hitting multiple profiles)
+- Backend rate-limit fanout (call goes 1:1, no parallel fan-out)
+
+---
+
+## Open questions
+
+1. **L2 fail-closed vs fail-open default?** Recommend fail-closed for safety;
+   profiles can override. Confirm.
+2. **Per-tool L3 toggle in addition to per-profile?** Some tools' responses are
+   structured-data-only (e.g., `slack_list_channels`) and L3 re-extraction adds
+   no value. Heuristic: skip L3 when response content-type indicates pure JSON
+   with no string fields > N chars. Worth doing in v1?
+3. **Long-lived sessions**: streamable-http supports session resumption. Should
+   airlock proxy session IDs transparently, or terminate at the gateway?
+4. **P-Agent backend blocklist semantics**: if mcp-atlassian keeps tripping L2
+   for a Josui profile, does the P-Agent blocklist apply per-profile or
+   globally?
+5. **Profile inheritance**: should profiles be able to inherit from a `default`
+   profile to share common deny patterns?
+
+---
+
+## Implementation phases
+
+| Phase | Scope | Estimated effort |
+|---|---|---|
+| 1 | Profile loader + auth + endpoint routing + tool allowlist filter (no defense pipeline yet) | ~half session |
+| 2 | L1 + L2 on tool-call responses; L3 with profile + Cockpit master switch | ~half session |
+| 3 | Audit log integration + Cockpit Gateway tab (read-only) | ~half session |
+| 4 | Cockpit profile editor + token rotation UI | ~half session |
+| 5 | Migration: Josui + Kagetora cut over to gateway endpoints | ~one session |
+
+Each phase is independently mergeable behind a feature flag (`AIRLOCK_GATEWAY_ENABLED=true`).
+
+---
+
+## References
+
+- Existing airlock 3-layer defense: `src/mcp_airlock_crunchtools/sanitize/`,
+  `quarantine/` (this repo)
+- crunchtools MCP fleet on lotor: see [[mcp-centralization-lotor]] memory note
+- Autonomous-agent constitution profile §V (kill switches): drives the L3
+  toggle requirement
+- FastMCP authentication middleware: https://gofastmcp.com/ (auth section)

--- a/examples/profiles-kagetora.yaml
+++ b/examples/profiles-kagetora.yaml
@@ -1,0 +1,207 @@
+# Kagetora gateway profile — tightened allowlists for context optimization
+#
+# Reduction: ~520 tools -> ~210 tools (60% cut)
+# Strategy: ["*"] for small backends (<20 tools), explicit allowlists for heavy ones
+# Audit: gateway_calls table logs every tools/call for data-driven future tightening
+
+profiles:
+  kagetora:
+    auth:
+      bearer_token_env: AIRLOCK_PROFILE_KAGETORA_TOKEN
+
+    backends:
+      # ── Internal (airlock's own tools) ──────────────────────────
+      web:
+        url: "internal://web"
+        tools_allow: ["*"]
+
+      # ── Small backends — keep all ───────────────────────────────
+      memory:
+        url: "http://mcp-memory:8006/mcp"
+        headers:
+          Authorization: "Bearer ${MCP_MEMORY_API_KEY}"
+        tools_allow: ["*"]
+
+      slack:
+        url: "http://mcp-slack:8005/mcp"
+        tools_allow: ["*"]
+
+      request-tracker:
+        url: "http://mcp-request-tracker:8008/mcp"
+        tools_allow: ["*"]
+
+      feed-reader:
+        url: "http://mcp-feed-reader:8004/mcp"
+        tools_allow: ["*"]
+
+      mediawiki:
+        url: "http://mcp-mediawiki:8009/mcp"
+        tools_allow: ["*"]
+
+      google-search-console:
+        url: "http://mcp-google-search-console:8010/mcp"
+        tools_allow: ["*"]
+
+      ashigaru:
+        url: "http://mcp-ashigaru:8020/mcp"
+        tools_allow: ["*"]
+
+      # ── GitHub (existing explicit allowlist) ────────────────────
+      github:
+        url: "http://mcp-github:8016/mcp"
+        tools_allow:
+          - list_repositories_tool
+          - get_repository_tool
+          - list_pull_requests_tool
+          - get_pull_request_tool
+          - get_pull_request_diff_tool
+          - get_pull_request_checks_tool
+          - list_issues_tool
+          - get_issue_tool
+          - create_issue_tool
+          - create_issue_comment_tool
+          - list_workflow_runs_tool
+          - rerun_workflow_run_tool
+          - rerun_failed_jobs_tool
+          - search_repositories_tool
+          - search_code_tool
+
+      # ── Atlassian/Jira (~40 -> ~14) ────────────────────────────
+      atlassian:
+        url: "http://mcp-atlassian:8021/mcp"
+        tools_allow:
+          # Search & read
+          - jira_search
+          - jira_get_issue
+          - jira_get_all_projects
+          - jira_get_project_issues
+          - jira_search_fields
+          # Write
+          - jira_create_issue
+          - jira_update_issue
+          - jira_add_comment
+          - jira_transition_issue
+          - jira_get_transitions
+          # Links
+          - jira_create_issue_link
+          - jira_get_link_types
+          - jira_link_to_epic
+          # Dev info (PR visibility for ashigaru)
+          - jira_get_issue_development_info
+
+      # ── GWS Personal (~130 -> ~25) ─────────────────────────────
+      gws-personal:
+        url: "http://gws-personal:8011/mcp"
+        tools_allow:
+          # Gmail
+          - search_gmail_messages
+          - get_gmail_message_content
+          - get_gmail_messages_content_batch
+          - get_gmail_thread_content
+          - get_gmail_threads_content_batch
+          - draft_gmail_message
+          - list_gmail_labels
+          - modify_gmail_message_labels
+          - batch_modify_gmail_message_labels
+          # Calendar
+          - get_events
+          - manage_event
+          - list_calendars
+          - query_freebusy
+          - manage_focus_time
+          - manage_out_of_office
+          # Tasks
+          - list_task_lists
+          - list_tasks
+          - get_task
+          - get_task_list
+          - manage_task
+          - manage_task_list
+          # Contacts
+          - search_contacts
+          - get_contact
+          # Drive (read-only)
+          - search_drive_files
+          - get_drive_file_content
+
+      # ── GWS Work (~130 -> ~15) ─────────────────────────────────
+      gws-work:
+        url: "http://gws-work:8012/mcp"
+        tools_allow:
+          # Gmail (read + draft)
+          - search_gmail_messages
+          - get_gmail_message_content
+          - get_gmail_messages_content_batch
+          - get_gmail_thread_content
+          - get_gmail_threads_content_batch
+          - draft_gmail_message
+          - list_gmail_labels
+          # Calendar
+          - get_events
+          - list_calendars
+          - query_freebusy
+          # Contacts
+          - search_contacts
+          - get_contact
+          # Drive (read-only)
+          - search_drive_files
+          - get_drive_file_content
+          - get_drive_file_download_url
+
+      # ── Gemini (~25 -> ~12) ────────────────────────────────────
+      gemini:
+        url: "http://mcp-gemini:8007/mcp"
+        tools_allow:
+          - gemini_query_tool
+          - gemini_search_tool
+          - gemini_generate_image_tool
+          - gemini_image_prompt_tool
+          - gemini_analyze_text_tool
+          - gemini_analyze_url_tool
+          - gemini_analyze_image_tool
+          - gemini_summarize_tool
+          - gemini_brainstorm_tool
+          - gemini_structured_tool
+          - gemini_extract_tool
+          - gemini_run_code_tool
+
+      # ── Cloudflare (~20 -> ~6, read-only) ──────────────────────
+      cloudflare:
+        url: "http://mcp-cloudflare:8003/mcp"
+        tools_allow:
+          - get_zone_analytics_tool
+          - get_security_events_tool
+          - get_top_pages_tool
+          - get_traffic_by_country_tool
+          - list_zones_tool
+          - get_zone_tool
+
+      # ── WordPress Crunchtools (~20 -> ~10) ─────────────────────
+      wordpress-crunchtools:
+        url: "http://mcp-wordpress-crunchtools:8013/mcp"
+        tools_allow:
+          - wordpress_list_posts
+          - wordpress_get_post
+          - wordpress_create_post
+          - wordpress_update_post
+          - wordpress_search_posts
+          - wordpress_list_categories
+          - wordpress_list_tags
+          - wordpress_upload_media
+          - wordpress_get_media_url
+          - wordpress_list_media
+
+      # ── WordPress Educated Confusion (~20 -> ~10) ──────────────
+      wordpress-educatedconfusion:
+        url: "http://mcp-wordpress-educatedconfusion:8014/mcp"
+        tools_allow:
+          - wordpress_list_posts
+          - wordpress_get_post
+          - wordpress_create_post
+          - wordpress_update_post
+          - wordpress_search_posts
+          - wordpress_list_categories
+          - wordpress_list_tags
+          - wordpress_upload_media
+          - wordpress_get_media_url
+          - wordpress_list_media

--- a/gourmand-exceptions.toml
+++ b/gourmand-exceptions.toml
@@ -202,3 +202,15 @@ check = "single_use_helpers"
 path = "cockpit-airlock/airlock.js"
 pattern = "init"
 justification = "UI lifecycle function — entry point that orchestrates page render, D-Bus connection, and signal setup"
+
+[[exceptions]]
+check = "generic_names"
+path = "src/mcp_airlock_crunchtools/gateway/router.py"
+pattern = "result"
+justification = "result is the JSON-RPC 2.0 wire-protocol field name for success responses (https://www.jsonrpc.org/specification §5.1); renaming would obscure the protocol mapping"
+
+[[exceptions]]
+check = "single_use_helpers"
+path = "src/mcp_airlock_crunchtools/__init__.py"
+pattern = "_run_with_gateway"
+justification = "Configuration gate isolated from the main() match statement so the gateway-disabled path stays a single mcp.run() call with no imports of starlette/uvicorn at startup time"

--- a/gourmand-exceptions.toml
+++ b/gourmand-exceptions.toml
@@ -214,3 +214,15 @@ check = "single_use_helpers"
 path = "src/mcp_airlock_crunchtools/__init__.py"
 pattern = "_run_with_gateway"
 justification = "Configuration gate isolated from the main() match statement so the gateway-disabled path stays a single mcp.run() call with no imports of starlette/uvicorn at startup time"
+
+[[exceptions]]
+check = "lint_suppression"
+path = "src/mcp_airlock_crunchtools/__init__.py"
+pattern = "type: ignore"
+justification = "Starlette's lifespan callable type signature uses opaque generics; the [no-untyped-def] ignore is the standard pattern for framework-supplied callbacks"
+
+[[exceptions]]
+check = "lint_suppression"
+path = "src/mcp_airlock_crunchtools/gateway/app.py"
+pattern = "type: ignore"
+justification = "FastMCP's custom_route decorator has no type stubs; the [misc] ignore is the standard pattern for typed code calling into untyped framework APIs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-airlock-crunchtools"
-version = "0.3.0"
+version = "0.4.0"
 description = "Secure MCP server for quarantined web content extraction and per-consumer MCP gateway — three-layer defense against prompt injection"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,14 @@
 [project]
 name = "mcp-airlock-crunchtools"
-version = "0.2.2"
-description = "Secure MCP server for quarantined web content extraction — two-layer defense against prompt injection"
+version = "0.3.0"
+description = "Secure MCP server for quarantined web content extraction and per-consumer MCP gateway — three-layer defense against prompt injection"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"
 authors = [
     { name = "crunchtools.com" }
 ]
 readme = "README.md"
-keywords = ["mcp", "security", "prompt-injection", "sanitization", "quarantine"]
+keywords = ["mcp", "security", "prompt-injection", "sanitization", "quarantine", "gateway"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -28,6 +28,7 @@ dependencies = [
     "transformers>=4.40",
     "numpy>=1.24",
     "dbus-fast>=2.0",
+    "pyyaml>=6.0",
 ]
 
 [project.optional-dependencies]
@@ -72,8 +73,9 @@ max-branches = 10
 max-statements = 50
 
 [tool.ruff.lint.per-file-ignores]
-"tests/*" = ["S105", "S108", "PLC0415", "PLR2004", "ARG002", "ARG005", "RUF003"]
+"tests/*" = ["S105", "S106", "S108", "PLC0415", "PLR2004", "ARG002", "ARG005", "RUF003", "PT018", "TC003"]
 "src/mcp_airlock_crunchtools/dbus_interface.py" = ["UP037", "C901", "TRY300"]
+"src/mcp_airlock_crunchtools/gateway/app.py" = ["C901", "PLR0911", "PLR0912"]
 
 [tool.mypy]
 python_version = "3.10"
@@ -82,7 +84,7 @@ warn_return_any = true
 warn_unused_configs = true
 
 [[tool.mypy.overrides]]
-module = ["markdownify", "bs4", "onnxruntime", "transformers", "dbus_fast", "dbus_fast.*"]
+module = ["markdownify", "bs4", "onnxruntime", "transformers", "dbus_fast", "dbus_fast.*", "yaml"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/src/mcp_airlock_crunchtools/__init__.py
+++ b/src/mcp_airlock_crunchtools/__init__.py
@@ -71,14 +71,19 @@ def _run_with_gateway(mcp_server: FastMCP, *, host: str, port: int) -> None:
     """Run airlock with gateway routes wired in via FastMCP's custom_route API.
 
     Loads profiles from AIRLOCK_PROFILES_PATH and registers
-    POST /gateway/{profile}/mcp endpoints on the FastMCP app. The existing
-    /mcp endpoint with the web-tools surface remains unchanged at the same
-    port — both surfaces live inside the same FastMCP-managed app.
+    POST /gateway/{profile}/mcp endpoints on the FastMCP app. Airlock's own
+    tools are bound as the in-process internal backend so profiles can surface
+    them (via an ``internal://<label>`` backend) through the same gateway
+    endpoint as the remote MCP backends.
+
+    The legacy /mcp endpoint with the web-tools surface is still registered by
+    mcp.run() at the same port, but Option C treats it as deprecated — consumers
+    talk to the gateway only.
 
     Failure to load profiles is fatal — we fail closed rather than serve with
     no gateway when the operator asked for one.
     """
-    from .gateway import load_profiles, register_with_fastmcp
+    from .gateway import load_profiles, register_internal_server, register_with_fastmcp
 
     profiles_path = Path(
         os.environ.get("AIRLOCK_PROFILES_PATH", "/etc/airlock/profiles.yaml")
@@ -86,6 +91,7 @@ def _run_with_gateway(mcp_server: FastMCP, *, host: str, port: int) -> None:
     logger.info("gateway: loading profiles from %s", profiles_path)
     registry = load_profiles(profiles_path)
 
+    register_internal_server(mcp_server)
     register_with_fastmcp(mcp_server, registry)
     logger.info(
         "gateway: registered %d profile(s) at /gateway/<profile>/mcp",

--- a/src/mcp_airlock_crunchtools/__init__.py
+++ b/src/mcp_airlock_crunchtools/__init__.py
@@ -68,20 +68,17 @@ def main() -> None:
 
 
 def _run_with_gateway(mcp_server: FastMCP, *, host: str, port: int) -> None:
-    """Run airlock with the gateway routes mounted alongside the FastMCP app.
+    """Run airlock with gateway routes wired in via FastMCP's custom_route API.
 
-    Loads profiles from AIRLOCK_PROFILES_PATH and exposes
-    POST /gateway/{profile}/mcp endpoints. The existing /mcp endpoint with
-    the web-tools surface remains unchanged at the same port.
+    Loads profiles from AIRLOCK_PROFILES_PATH and registers
+    POST /gateway/{profile}/mcp endpoints on the FastMCP app. The existing
+    /mcp endpoint with the web-tools surface remains unchanged at the same
+    port — both surfaces live inside the same FastMCP-managed app.
 
     Failure to load profiles is fatal — we fail closed rather than serve with
     no gateway when the operator asked for one.
     """
-    import uvicorn
-    from starlette.applications import Starlette
-    from starlette.routing import Mount
-
-    from .gateway import gateway_app, load_profiles
+    from .gateway import load_profiles, register_with_fastmcp
 
     profiles_path = Path(
         os.environ.get("AIRLOCK_PROFILES_PATH", "/etc/airlock/profiles.yaml")
@@ -89,20 +86,10 @@ def _run_with_gateway(mcp_server: FastMCP, *, host: str, port: int) -> None:
     logger.info("gateway: loading profiles from %s", profiles_path)
     registry = load_profiles(profiles_path)
 
-    fastmcp_app = mcp_server.http_app(transport="streamable-http")
-    gw_app = gateway_app(registry)
-
-    parent = Starlette(
-        routes=[
-            Mount("/", app=gw_app),
-            Mount("/", app=fastmcp_app),
-        ]
-    )
-
+    register_with_fastmcp(mcp_server, registry)
     logger.info(
-        "gateway: mounted %d profile(s); listening on %s:%d",
+        "gateway: registered %d profile(s) at /gateway/<profile>/mcp",
         len(registry),
-        host,
-        port,
     )
-    uvicorn.run(parent, host=host, port=port, log_config=None)
+
+    mcp_server.run(transport="streamable-http", host=host, port=port)

--- a/src/mcp_airlock_crunchtools/__init__.py
+++ b/src/mcp_airlock_crunchtools/__init__.py
@@ -1,23 +1,30 @@
-"""mcp-airlock-crunchtools: Quarantined web content extraction."""
+"""mcp-airlock-crunchtools: Quarantined web content extraction + MCP gateway."""
 
 from __future__ import annotations
 
 import argparse
 import asyncio
 import logging
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING
 
-__version__ = "0.2.2"
+__version__ = "0.3.0"
 
 DEFAULT_PORT = 8019
+_TRUTHY = {"1", "true", "yes", "on"}
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
 
 
 def main() -> None:
     """Entry point for mcp-airlock-crunchtools."""
     parser = argparse.ArgumentParser(
         prog="mcp-airlock-crunchtools",
-        description="MCP server for quarantined web content extraction",
+        description="MCP server for quarantined web content extraction and gateway",
     )
     parser.add_argument(
         "--transport",
@@ -46,10 +53,56 @@ def main() -> None:
         loop.run_until_complete(start_dbus())
         loop.close()
 
+    gateway_enabled = os.environ.get("AIRLOCK_GATEWAY_ENABLED", "").strip().lower() in _TRUTHY
+
     match args.transport:
         case "stdio":
             mcp.run(transport="stdio")
         case "sse":
             mcp.run(transport="sse", host=args.host, port=args.port)
         case _:
-            mcp.run(transport="streamable-http", host=args.host, port=args.port)
+            if gateway_enabled:
+                _run_with_gateway(mcp, host=args.host, port=args.port)
+            else:
+                mcp.run(transport="streamable-http", host=args.host, port=args.port)
+
+
+def _run_with_gateway(mcp_server: FastMCP, *, host: str, port: int) -> None:
+    """Run airlock with the gateway routes mounted alongside the FastMCP app.
+
+    Loads profiles from AIRLOCK_PROFILES_PATH and exposes
+    POST /gateway/{profile}/mcp endpoints. The existing /mcp endpoint with
+    the web-tools surface remains unchanged at the same port.
+
+    Failure to load profiles is fatal — we fail closed rather than serve with
+    no gateway when the operator asked for one.
+    """
+    import uvicorn
+    from starlette.applications import Starlette
+    from starlette.routing import Mount
+
+    from .gateway import gateway_app, load_profiles
+
+    profiles_path = Path(
+        os.environ.get("AIRLOCK_PROFILES_PATH", "/etc/airlock/profiles.yaml")
+    )
+    logger.info("gateway: loading profiles from %s", profiles_path)
+    registry = load_profiles(profiles_path)
+
+    fastmcp_app = mcp_server.http_app(transport="streamable-http")
+    gw_app = gateway_app(registry)
+
+    parent = Starlette(
+        routes=[
+            Mount("/", app=gw_app),
+            Mount("/", app=fastmcp_app),
+        ]
+    )
+
+    logger.info(
+        "gateway: mounted %d profile(s); listening on %s:%d",
+        len(registry),
+        host,
+        port,
+    )
+    uvicorn.run(parent, host=host, port=port, log_config=None)

--- a/src/mcp_airlock_crunchtools/__init__.py
+++ b/src/mcp_airlock_crunchtools/__init__.py
@@ -9,7 +9,7 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 DEFAULT_PORT = 8019
 _TRUTHY = {"1", "true", "yes", "on"}

--- a/src/mcp_airlock_crunchtools/database.py
+++ b/src/mcp_airlock_crunchtools/database.py
@@ -8,11 +8,15 @@ deterministic code, which decides whether to record a detection.
 from __future__ import annotations
 
 import json
+import logging
 import sqlite3
+import time
 from datetime import datetime, timezone
 from typing import Any
 
 from .config import get_config
+
+logger = logging.getLogger(__name__)
 
 _db: sqlite3.Connection | None = None
 
@@ -31,6 +35,20 @@ CREATE TABLE IF NOT EXISTS detections (
 
 CREATE INDEX IF NOT EXISTS idx_detections_domain ON detections(domain);
 CREATE INDEX IF NOT EXISTS idx_detections_source ON detections(source);
+
+CREATE TABLE IF NOT EXISTS gateway_calls (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp REAL NOT NULL,
+    profile TEXT NOT NULL,
+    backend TEXT NOT NULL,
+    tool TEXT NOT NULL,
+    success BOOLEAN NOT NULL,
+    duration_ms INTEGER NOT NULL,
+    error_message TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_gateway_calls_timestamp ON gateway_calls(timestamp);
+CREATE INDEX IF NOT EXISTS idx_gateway_calls_profile_tool ON gateway_calls(profile, backend, tool);
 """
 
 
@@ -119,4 +137,78 @@ def get_blocklist_stats() -> dict[str, Any]:
         "total_blocked": total["cnt"] if total else 0,
         "by_risk_level": {row["risk_level"]: row["cnt"] for row in by_risk},
         "recent_detections": [dict(row) for row in recent],
+    }
+
+
+# -- Gateway audit --
+
+
+def record_gateway_call(
+    profile: str,
+    backend: str,
+    tool: str,
+    success: bool,
+    duration_ms: int,
+    error_message: str | None = None,
+) -> None:
+    """Record a gateway tools/call invocation. Never raises."""
+    try:
+        db = get_db()
+        db.execute(
+            "INSERT INTO gateway_calls "
+            "(timestamp, profile, backend, tool, success, duration_ms, error_message) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (time.time(), profile, backend, tool, success, duration_ms, error_message),
+        )
+        db.commit()
+    except Exception:
+        logger.warning(
+            "gateway audit: failed to record call %s/%s/%s",
+            profile, backend, tool, exc_info=True,
+        )
+
+
+def get_gateway_call_stats(
+    profile: str | None = None,
+    days: int = 30,
+) -> dict[str, Any]:
+    """Per-backend/per-tool call counts for data-driven allowlist tightening."""
+    db = get_db()
+    cutoff = time.time() - (days * 86400)
+
+    if profile:
+        rows = db.execute(
+            "SELECT backend, tool, COUNT(*) as cnt, "
+            "SUM(CASE WHEN success THEN 1 ELSE 0 END) as ok, "
+            "SUM(CASE WHEN NOT success THEN 1 ELSE 0 END) as err "
+            "FROM gateway_calls WHERE profile = ? AND timestamp > ? "
+            "GROUP BY backend, tool ORDER BY cnt DESC",
+            (profile, cutoff),
+        ).fetchall()
+    else:
+        rows = db.execute(
+            "SELECT backend, tool, COUNT(*) as cnt, "
+            "SUM(CASE WHEN success THEN 1 ELSE 0 END) as ok, "
+            "SUM(CASE WHEN NOT success THEN 1 ELSE 0 END) as err "
+            "FROM gateway_calls WHERE timestamp > ? "
+            "GROUP BY backend, tool ORDER BY cnt DESC",
+            (cutoff,),
+        ).fetchall()
+
+    total_row = db.execute(
+        "SELECT COUNT(*) as cnt FROM gateway_calls WHERE timestamp > ?",
+        (cutoff,),
+    ).fetchone()
+
+    return {
+        "total_calls": total_row["cnt"] if total_row else 0,
+        "days": days,
+        "profile_filter": profile,
+        "by_tool": [
+            {
+                "backend": r["backend"], "tool": r["tool"],
+                "calls": r["cnt"], "ok": r["ok"], "errors": r["err"],
+            }
+            for r in rows
+        ],
     }

--- a/src/mcp_airlock_crunchtools/database.py
+++ b/src/mcp_airlock_crunchtools/database.py
@@ -8,15 +8,12 @@ deterministic code, which decides whether to record a detection.
 from __future__ import annotations
 
 import json
-import logging
 import sqlite3
 import time
 from datetime import datetime, timezone
 from typing import Any
 
 from .config import get_config
-
-logger = logging.getLogger(__name__)
 
 _db: sqlite3.Connection | None = None
 
@@ -140,9 +137,6 @@ def get_blocklist_stats() -> dict[str, Any]:
     }
 
 
-# -- Gateway audit --
-
-
 def record_gateway_call(
     profile: str,
     backend: str,
@@ -151,21 +145,15 @@ def record_gateway_call(
     duration_ms: int,
     error_message: str | None = None,
 ) -> None:
-    """Record a gateway tools/call invocation. Never raises."""
-    try:
-        db = get_db()
-        db.execute(
-            "INSERT INTO gateway_calls "
-            "(timestamp, profile, backend, tool, success, duration_ms, error_message) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (time.time(), profile, backend, tool, success, duration_ms, error_message),
-        )
-        db.commit()
-    except Exception:
-        logger.warning(
-            "gateway audit: failed to record call %s/%s/%s",
-            profile, backend, tool, exc_info=True,
-        )
+    """Record a gateway tools/call invocation."""
+    db = get_db()
+    db.execute(
+        "INSERT INTO gateway_calls "
+        "(timestamp, profile, backend, tool, success, duration_ms, error_message) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (time.time(), profile, backend, tool, success, duration_ms, error_message),
+    )
+    db.commit()
 
 
 def get_gateway_call_stats(

--- a/src/mcp_airlock_crunchtools/gateway/__init__.py
+++ b/src/mcp_airlock_crunchtools/gateway/__init__.py
@@ -16,6 +16,12 @@ from .auth import verify_bearer
 from .backend import BackendCall, call_backend_tool, list_backend_tools
 from .errors import AuthError, GatewayError, ProfileConfigError
 from .filter import filter_tools
+from .internal import (
+    call_internal_tool,
+    internal_server_registered,
+    list_internal_tools,
+    register_internal_server,
+)
 from .loader import load_profiles
 from .profile import AuthConfig, Backend, DefenseConfig, Profile
 from .router import route_jsonrpc
@@ -30,10 +36,14 @@ __all__ = [
     "Profile",
     "ProfileConfigError",
     "call_backend_tool",
+    "call_internal_tool",
     "filter_tools",
     "gateway_app",
+    "internal_server_registered",
     "list_backend_tools",
+    "list_internal_tools",
     "load_profiles",
+    "register_internal_server",
     "register_with_fastmcp",
     "route_jsonrpc",
     "verify_bearer",

--- a/src/mcp_airlock_crunchtools/gateway/__init__.py
+++ b/src/mcp_airlock_crunchtools/gateway/__init__.py
@@ -11,7 +11,7 @@ full design and phase plan.
 
 from __future__ import annotations
 
-from .app import gateway_app
+from .app import gateway_app, register_with_fastmcp
 from .auth import verify_bearer
 from .backend import BackendCall, call_backend_tool, list_backend_tools
 from .errors import AuthError, GatewayError, ProfileConfigError
@@ -34,6 +34,7 @@ __all__ = [
     "gateway_app",
     "list_backend_tools",
     "load_profiles",
+    "register_with_fastmcp",
     "route_jsonrpc",
     "verify_bearer",
 ]

--- a/src/mcp_airlock_crunchtools/gateway/__init__.py
+++ b/src/mcp_airlock_crunchtools/gateway/__init__.py
@@ -1,0 +1,39 @@
+"""Gateway subpackage — per-consumer MCP proxy with tool-allowlist filtering.
+
+Phase 1 scope: profile loader, bearer-token auth, JSON-RPC dispatch,
+tool-name allowlist filter on tools/list responses, transparent tools/call
+passthrough to backend MCP servers. No defense pipeline application yet —
+that arrives in Phase 2.
+
+See docs/gateway-design.md and .specify/specs/006-gateway-mode/ for the
+full design and phase plan.
+"""
+
+from __future__ import annotations
+
+from .app import gateway_app
+from .auth import verify_bearer
+from .backend import BackendCall, call_backend_tool, list_backend_tools
+from .errors import AuthError, GatewayError, ProfileConfigError
+from .filter import filter_tools
+from .loader import load_profiles
+from .profile import AuthConfig, Backend, DefenseConfig, Profile
+from .router import route_jsonrpc
+
+__all__ = [
+    "AuthConfig",
+    "AuthError",
+    "Backend",
+    "BackendCall",
+    "DefenseConfig",
+    "GatewayError",
+    "Profile",
+    "ProfileConfigError",
+    "call_backend_tool",
+    "filter_tools",
+    "gateway_app",
+    "list_backend_tools",
+    "load_profiles",
+    "route_jsonrpc",
+    "verify_bearer",
+]

--- a/src/mcp_airlock_crunchtools/gateway/app.py
+++ b/src/mcp_airlock_crunchtools/gateway/app.py
@@ -34,14 +34,15 @@ logger = logging.getLogger(__name__)
 
 
 def gateway_app(registry: dict[str, Profile]) -> Starlette:
-    """Build the Starlette sub-app exposing /gateway/{profile}/mcp.
+    """Build the Starlette sub-app exposing /{profile}/mcp.
+
+    Used by tests with Starlette's TestClient. Production deployment wires
+    the same handler via `register_with_fastmcp` to avoid mount-composition
+    issues with FastMCP's own internal routing.
 
     Args:
         registry: Mapping from profile name to loaded `Profile` (returned by
             `loader.load_profiles`).
-
-    Returns:
-        A Starlette app with one route family. Mount under `/` in a parent.
     """
 
     async def handle_post(request: Request) -> Response:
@@ -52,17 +53,38 @@ def gateway_app(registry: dict[str, Profile]) -> Starlette:
 
     routes = [
         Route(
-            "/gateway/{profile}/mcp",
+            "/{profile}/mcp",
             endpoint=handle_post,
             methods=["POST"],
         ),
         Route(
-            "/gateway/{profile}/mcp",
+            "/{profile}/mcp",
             endpoint=handle_method_not_allowed,
             methods=["GET", "DELETE"],
         ),
     ]
     return Starlette(routes=routes)
+
+
+def register_with_fastmcp(mcp_server: Any, registry: dict[str, Profile]) -> None:
+    """Wire gateway routes onto a FastMCP server via its custom_route decorator.
+
+    FastMCP exposes `custom_route(path, methods)` precisely for this kind of
+    additional HTTP surface (OAuth callbacks, health endpoints, admin APIs).
+    Going through that API rather than wrapping the FastMCP app in a parent
+    Starlette keeps the existing /mcp surface intact and preserves FastMCP's
+    internal routing assumptions.
+
+    A single handler covers POST + GET + DELETE so we don't register two
+    Route objects at the same path — fastmcp 3.1.1's dispatch can be flaky
+    with overlapping custom routes.
+    """
+
+    @mcp_server.custom_route("/gateway/{profile}/mcp", methods=["POST", "GET", "DELETE"])  # type: ignore[untyped-decorator]
+    async def gateway_endpoint(request: Request) -> Response:
+        if request.method != "POST":
+            return _plain(405, "Method Not Allowed (Phase 1 supports POST only)")
+        return await _handle_post(request, registry)
 
 
 async def _handle_post(request: Request, registry: dict[str, Profile]) -> Response:

--- a/src/mcp_airlock_crunchtools/gateway/app.py
+++ b/src/mcp_airlock_crunchtools/gateway/app.py
@@ -1,0 +1,157 @@
+"""Starlette routes for the gateway endpoint family.
+
+`POST /gateway/{profile}/mcp` is the only method served in Phase 1. `GET`
+and `DELETE` (used for streamable-http session management) return 405;
+Phase 1 is a stateless-per-call gateway with no session resumption support.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+from starlette.applications import Starlette
+from starlette.responses import JSONResponse, Response
+from starlette.routing import Route
+
+from .auth import verify_bearer
+from .errors import (
+    AuthError,
+    BackendCallError,
+    BackendNotInProfileError,
+    GatewayError,
+    ProfileNotFoundError,
+)
+from .router import route_jsonrpc
+
+if TYPE_CHECKING:
+    from starlette.requests import Request
+
+    from .profile import Profile
+
+logger = logging.getLogger(__name__)
+
+
+def gateway_app(registry: dict[str, Profile]) -> Starlette:
+    """Build the Starlette sub-app exposing /gateway/{profile}/mcp.
+
+    Args:
+        registry: Mapping from profile name to loaded `Profile` (returned by
+            `loader.load_profiles`).
+
+    Returns:
+        A Starlette app with one route family. Mount under `/` in a parent.
+    """
+
+    async def handle_post(request: Request) -> Response:
+        return await _handle_post(request, registry)
+
+    async def handle_method_not_allowed(_request: Request) -> Response:
+        return _plain(405, "Method Not Allowed (Phase 1 supports POST only)")
+
+    routes = [
+        Route(
+            "/gateway/{profile}/mcp",
+            endpoint=handle_post,
+            methods=["POST"],
+        ),
+        Route(
+            "/gateway/{profile}/mcp",
+            endpoint=handle_method_not_allowed,
+            methods=["GET", "DELETE"],
+        ),
+    ]
+    return Starlette(routes=routes)
+
+
+async def _handle_post(request: Request, registry: dict[str, Profile]) -> Response:
+    """Authenticate, parse, dispatch, and return one gateway JSON-RPC request.
+
+    Failure modes and their mappings:
+        unknown profile        -> HTTP 404
+        missing/bad auth       -> HTTP 401
+        unreadable body        -> HTTP 400
+        empty body             -> HTTP 400
+        body is not JSON       -> HTTP 400
+        body is not an object  -> HTTP 400
+        backend in JSON-RPC error path -> HTTP 200 with JSON-RPC error body
+        backend transport failure      -> HTTP 502 with JSON-RPC error body
+        any other GatewayError -> HTTP 500 (logged with traceback)
+    """
+    profile_name = request.path_params.get("profile", "")
+    profile = registry.get(profile_name)
+    if profile is None:
+        logger.info("gateway: unknown profile %r", profile_name)
+        return _plain(404, "Not Found")
+
+    try:
+        verify_bearer(request.headers.get("authorization"), profile)
+    except AuthError as exc:
+        logger.info("gateway: auth failed profile=%s reason=%s", profile_name, exc)
+        return _plain(401, "Unauthorized")
+
+    try:
+        body_bytes = await request.body()
+    except Exception:
+        return _plain(400, "Bad Request: cannot read body")
+
+    if not body_bytes:
+        return _plain(400, "Bad Request: empty body")
+
+    try:
+        body: Any = json.loads(body_bytes)
+    except json.JSONDecodeError:
+        return _plain(400, "Bad Request: body is not valid JSON")
+
+    if not isinstance(body, dict):
+        return _plain(400, "Bad Request: JSON-RPC body must be an object")
+
+    try:
+        response = await route_jsonrpc(profile, body)
+    except BackendNotInProfileError as exc:
+        return JSONResponse(
+            {
+                "jsonrpc": "2.0",
+                "id": body.get("id"),
+                "error": {"code": -32602, "message": str(exc)},
+            }
+        )
+    except ProfileNotFoundError:
+        return _plain(404, "Not Found")
+    except BackendCallError as exc:
+        return JSONResponse(
+            {
+                "jsonrpc": "2.0",
+                "id": body.get("id"),
+                "error": {"code": -32603, "message": str(exc)},
+            },
+            status_code=502,
+        )
+    except GatewayError:
+        logger.exception("gateway: unexpected gateway error profile=%s", profile_name)
+        return JSONResponse(
+            {
+                "jsonrpc": "2.0",
+                "id": body.get("id"),
+                "error": {"code": -32603, "message": "Internal gateway error"},
+            },
+            status_code=500,
+        )
+    except Exception:
+        logger.exception("gateway: unhandled error profile=%s", profile_name)
+        return JSONResponse(
+            {
+                "jsonrpc": "2.0",
+                "id": body.get("id"),
+                "error": {"code": -32603, "message": "Internal error"},
+            },
+            status_code=500,
+        )
+
+    return JSONResponse(response)
+
+
+def _plain(status: int, text: str) -> Response:
+    """Build a plain-text response with the given status code."""
+    return Response(content=text, media_type="text/plain", status_code=status)

--- a/src/mcp_airlock_crunchtools/gateway/auth.py
+++ b/src/mcp_airlock_crunchtools/gateway/auth.py
@@ -1,0 +1,46 @@
+"""Bearer-token authentication for gateway endpoints.
+
+Constant-time comparison via `hmac.compare_digest` defends against timing
+oracles. Errors carry no token content.
+"""
+
+from __future__ import annotations
+
+import hmac
+from typing import TYPE_CHECKING
+
+from .errors import AuthError
+
+if TYPE_CHECKING:
+    from .profile import Profile
+
+
+def verify_bearer(authorization_header: str | None, profile: Profile) -> None:
+    """Verify the Authorization header against the profile's resolved bearer token.
+
+    The header must use the `Bearer` scheme (case-insensitive). The presented
+    token is compared in constant time against the profile's resolved token,
+    which the loader set at startup from the env var named in the profile.
+
+    Args:
+        authorization_header: Raw value of the request `Authorization` header,
+            or None if the header is absent.
+        profile: The profile being accessed.
+
+    Raises:
+        AuthError: header missing, malformed, profile token not resolved, or
+            token mismatch. Caller maps this to HTTP 401.
+    """
+    if not authorization_header:
+        raise AuthError("missing authorization")
+
+    scheme, _, presented = authorization_header.partition(" ")
+    if scheme.lower() != "bearer" or not presented:
+        raise AuthError("malformed authorization")
+
+    if profile.auth.bearer_token is None:
+        raise AuthError("profile token not resolved")
+
+    expected = profile.auth.bearer_token.get_secret_value()
+    if not hmac.compare_digest(presented.encode("utf-8"), expected.encode("utf-8")):
+        raise AuthError("invalid token")

--- a/src/mcp_airlock_crunchtools/gateway/backend.py
+++ b/src/mcp_airlock_crunchtools/gateway/backend.py
@@ -148,8 +148,13 @@ def _serialize_tool(tool: Any) -> dict[str, Any]:
     }
     for extra in ("title", "annotations", "outputSchema"):
         value = getattr(tool, extra, None)
-        if value is not None:
-            out[extra] = value
+        if value is None:
+            continue
+        # annotations (and sometimes outputSchema) come back as pydantic models
+        # (e.g. ToolAnnotations), which are not directly JSON-serializable.
+        if hasattr(value, "model_dump"):
+            value = value.model_dump(mode="json", by_alias=True, exclude_none=True)
+        out[extra] = value
     return out
 
 

--- a/src/mcp_airlock_crunchtools/gateway/backend.py
+++ b/src/mcp_airlock_crunchtools/gateway/backend.py
@@ -150,8 +150,6 @@ def _serialize_tool(tool: Any) -> dict[str, Any]:
         value = getattr(tool, extra, None)
         if value is None:
             continue
-        # annotations (and sometimes outputSchema) come back as pydantic models
-        # (e.g. ToolAnnotations), which are not directly JSON-serializable.
         if hasattr(value, "model_dump"):
             value = value.model_dump(mode="json", by_alias=True, exclude_none=True)
         out[extra] = value

--- a/src/mcp_airlock_crunchtools/gateway/backend.py
+++ b/src/mcp_airlock_crunchtools/gateway/backend.py
@@ -1,0 +1,169 @@
+"""Backend MCP connection management.
+
+Phase 1 opens a fresh `streamablehttp_client` session per call. No connection
+pooling — that arrives in Phase 2 as an optimization. Each call to a backend
+establishes its own MCP session, performs the requested op, and tears down.
+
+Simple lifecycle, visible chokepoint, easy to debug. Pool-sharing under load
+is the next step once Phase 1 architecture is proven.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+from .errors import BackendCallError
+
+if TYPE_CHECKING:
+    from .profile import Backend
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class BackendCall:
+    """Outcome of a backend tool invocation."""
+
+    content: list[dict[str, Any]]
+    is_error: bool
+    structured_content: dict[str, Any] | None
+
+
+async def list_backend_tools(backend_name: str, backend: Backend) -> list[dict[str, Any]]:
+    """Fetch the tool list from one backend MCP server.
+
+    Returns the raw tool list as the backend reported it (no allowlist filtering
+    here — that's `filter.py`'s job). Tool names are NOT yet namespaced; the
+    caller does the `<backend>__<tool>` rewrite.
+
+    Raises:
+        BackendCallError: connection failure, protocol error, or timeout.
+    """
+    headers = backend.headers or None
+    try:
+        tools_result = await asyncio.wait_for(
+            _do_list_tools(backend.url, headers),
+            timeout=backend.timeout_seconds,
+        )
+    except Exception as exc:
+        logger.warning(
+            "gateway: list_tools failed for backend=%s url=%s err=%s",
+            backend_name,
+            backend.url,
+            exc,
+        )
+        raise BackendCallError(
+            f"backend {backend_name!r} list_tools failed: {type(exc).__name__}"
+        ) from exc
+
+    return [_serialize_tool(tool) for tool in tools_result.tools]
+
+
+async def call_backend_tool(
+    backend_name: str,
+    backend: Backend,
+    tool_name: str,
+    arguments: dict[str, Any],
+) -> BackendCall:
+    """Invoke a tool on a backend MCP server, returning the raw result.
+
+    Phase 1 passes the response through verbatim. Phase 2 wraps it in the
+    L1/L2/L3 defense pipeline before returning.
+
+    Raises:
+        BackendCallError: connection failure, protocol error, or timeout.
+    """
+    headers = backend.headers or None
+    try:
+        result = await asyncio.wait_for(
+            _do_call_tool(backend.url, headers, tool_name, arguments),
+            timeout=backend.timeout_seconds,
+        )
+    except Exception as exc:
+        logger.warning(
+            "gateway: call_tool failed backend=%s tool=%s err=%s",
+            backend_name,
+            tool_name,
+            exc,
+        )
+        raise BackendCallError(
+            f"backend {backend_name!r} call_tool failed: {type(exc).__name__}"
+        ) from exc
+
+    content: list[dict[str, Any]] = [_serialize_content_block(b) for b in result.content]
+    structured = getattr(result, "structuredContent", None)
+    return BackendCall(
+        content=content,
+        is_error=bool(result.isError),
+        structured_content=structured if isinstance(structured, dict) else None,
+    )
+
+
+async def _do_list_tools(url: str, headers: dict[str, str] | None) -> Any:
+    """Open a session and call list_tools.
+
+    Extracted as a separate coroutine so `asyncio.wait_for` can wrap it
+    cleanly (the connection setup and the protocol call both need the
+    timeout, not just the call).
+    """
+    async with (
+        streamablehttp_client(url, headers=headers) as (read, write, _),
+        ClientSession(read, write) as session,
+    ):
+        await session.initialize()
+        return await session.list_tools()
+
+
+async def _do_call_tool(
+    url: str,
+    headers: dict[str, str] | None,
+    tool_name: str,
+    arguments: dict[str, Any],
+) -> Any:
+    """Open a session and call_tool, parallel to `_do_list_tools`.
+
+    Separate coroutine so `asyncio.wait_for` covers the full lifecycle of
+    the backend session, not just the protocol call.
+    """
+    async with (
+        streamablehttp_client(url, headers=headers) as (read, write, _),
+        ClientSession(read, write) as session,
+    ):
+        await session.initialize()
+        return await session.call_tool(tool_name, arguments=arguments)
+
+
+def _serialize_tool(tool: Any) -> dict[str, Any]:
+    """Convert an MCP Tool dataclass to a JSON-serializable dict."""
+    out: dict[str, Any] = {
+        "name": tool.name,
+        "description": tool.description or "",
+        "inputSchema": tool.inputSchema,
+    }
+    for extra in ("title", "annotations", "outputSchema"):
+        value = getattr(tool, extra, None)
+        if value is not None:
+            out[extra] = value
+    return out
+
+
+def _serialize_content_block(block: Any) -> dict[str, Any]:
+    """Convert an MCP content block (TextContent, ImageContent, etc.) to a dict."""
+    kind = getattr(block, "type", None)
+    if kind == "text":
+        return {"type": "text", "text": getattr(block, "text", "")}
+    if kind == "image":
+        return {
+            "type": "image",
+            "data": getattr(block, "data", ""),
+            "mimeType": getattr(block, "mimeType", ""),
+        }
+    if kind == "resource":
+        return {"type": "resource", "resource": getattr(block, "resource", {})}
+    return {"type": kind or "unknown", "_repr": repr(block)[:200]}

--- a/src/mcp_airlock_crunchtools/gateway/errors.py
+++ b/src/mcp_airlock_crunchtools/gateway/errors.py
@@ -1,0 +1,48 @@
+"""Gateway-specific error types.
+
+Error messages here are deliberately terse. They never disclose bearer-token
+content, profile contents beyond the profile name, or backend connection
+details to the consumer. Detail goes to the structured log only.
+"""
+
+from __future__ import annotations
+
+
+class GatewayError(Exception):
+    """Base class for gateway errors."""
+
+
+class ProfileConfigError(GatewayError):
+    """Raised at startup when the profiles YAML is missing or invalid.
+
+    Gateway routes are not mounted if profile loading fails while
+    AIRLOCK_GATEWAY_ENABLED is true. Fails closed.
+    """
+
+
+class AuthError(GatewayError):
+    """Raised on missing, malformed, or mismatched bearer token.
+
+    Maps to HTTP 401 with no body detail beyond a fixed string.
+    """
+
+
+class ProfileNotFoundError(GatewayError):
+    """Raised when a request targets a profile not in the loaded registry.
+
+    Maps to HTTP 404.
+    """
+
+
+class BackendNotInProfileError(GatewayError):
+    """Raised when a tool call targets a backend not present in the profile.
+
+    Maps to JSON-RPC error -32602 (invalid params).
+    """
+
+
+class BackendCallError(GatewayError):
+    """Raised when a backend MCP call fails (network, timeout, malformed response).
+
+    Maps to JSON-RPC error -32603 (internal error) and HTTP 502 to the consumer.
+    """

--- a/src/mcp_airlock_crunchtools/gateway/filter.py
+++ b/src/mcp_airlock_crunchtools/gateway/filter.py
@@ -1,0 +1,47 @@
+"""Tool-allowlist filter for `tools/list` responses.
+
+Applied to the aggregated backend tool list before returning to the consumer.
+Tool definitions excluded by the filter never reach the consumer's prompt
+context — this is where actual token savings come from versus settings.json
+deny lists which keep definitions in context.
+"""
+
+from __future__ import annotations
+
+from fnmatch import fnmatchcase
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .profile import Backend
+
+
+def filter_tools(tools: list[dict[str, Any]], backend: Backend) -> list[dict[str, Any]]:
+    """Filter a backend's tool list against the backend's allow/deny patterns.
+
+    A tool is kept iff its name matches any allow pattern AND does not match
+    any deny pattern. Patterns use shell-style globs validated at profile
+    load time (see profile.GLOB_PATTERN_RE).
+
+    Args:
+        tools: List of MCP tool definitions (each a dict with at least "name").
+        backend: Backend config carrying `tools_allow` + `tools_deny` glob lists.
+
+    Returns:
+        Filtered tool list. Empty `tools_allow` results in an empty output —
+        the default model value is `["*"]` (allow all), so a profile must
+        explicitly opt out of that to reach the empty-allow case.
+    """
+    allow = backend.tools_allow
+    deny = backend.tools_deny
+
+    kept: list[dict[str, Any]] = []
+    for tool in tools:
+        name = str(tool.get("name", ""))
+        if not name:
+            continue
+        if not any(fnmatchcase(name, pat) for pat in allow):
+            continue
+        if deny and any(fnmatchcase(name, pat) for pat in deny):
+            continue
+        kept.append(tool)
+    return kept

--- a/src/mcp_airlock_crunchtools/gateway/internal.py
+++ b/src/mcp_airlock_crunchtools/gateway/internal.py
@@ -1,0 +1,105 @@
+"""Internal-tool backend: airlock's own FastMCP tools as a gateway backend.
+
+Option C folds airlock's native tool surface (safe_fetch, quarantine_*, scan,
+stats, …) into the gateway alongside the remote http(s) MCP backends. A profile
+backend whose URL uses the ``internal://<label>`` scheme routes here instead of
+opening a streamable-http session: the whole airlock tool surface becomes one
+backend, namespaced under whatever key the profile gives it (conventionally
+``web``). The ``<label>`` after the scheme is cosmetic — there is exactly one
+internal source, the airlock FastMCP server itself.
+
+The bound server is a module-level singleton, populated once at startup from the
+FastMCP instance (see ``__init__._run_with_gateway``). This mirrors backend.py's
+module-function style so router.py can dispatch on URL scheme with a parallel
+call shape (``list_*``/``call_*`` returning the same types as the http path).
+
+Tool listing and result serialization reuse backend.py's helpers, so an
+internal tool and a remote tool present identically to the consumer.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from .backend import BackendCall, _serialize_content_block, _serialize_tool
+from .errors import BackendCallError
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+logger = logging.getLogger(__name__)
+
+_server: FastMCP | None = None
+
+
+def register_internal_server(mcp_server: FastMCP) -> None:
+    """Bind the FastMCP server whose tools the internal backend exposes.
+
+    Called once at startup. Idempotent — re-binding simply replaces the
+    reference (useful in tests).
+    """
+    global _server
+    _server = mcp_server
+    logger.info(
+        "gateway: internal tool backend bound to FastMCP server %r",
+        getattr(mcp_server, "name", "?"),
+    )
+
+
+def internal_server_registered() -> bool:
+    """Report whether an internal FastMCP server has been bound."""
+    return _server is not None
+
+
+async def list_internal_tools() -> list[dict[str, Any]]:
+    """Fetch airlock's own tool list, serialized like a remote backend's.
+
+    Returns the raw (un-namespaced, un-filtered) tool list — the router applies
+    the profile allowlist and the ``<backend>__<tool>`` namespacing, exactly as
+    it does for http backends.
+
+    Raises:
+        BackendCallError: no server bound, or the FastMCP tool walk failed.
+    """
+    if _server is None:
+        raise BackendCallError("internal tool backend not registered")
+    try:
+        tools = await _server.list_tools()
+    except Exception as exc:
+        logger.warning("gateway: internal list_tools failed err=%s", exc)
+        raise BackendCallError(
+            f"internal list_tools failed: {type(exc).__name__}"
+        ) from exc
+
+    return [_serialize_tool(tool.to_mcp_tool()) for tool in tools]
+
+
+async def call_internal_tool(tool_name: str, arguments: dict[str, Any]) -> BackendCall:
+    """Invoke an airlock tool in-process, returning a BackendCall like the http path.
+
+    Phase 1 returns the tool result verbatim. Phase 2 wraps it in the L1/L2/L3
+    defense pipeline at the router, identically to remote backends.
+
+    Raises:
+        BackendCallError: no server bound, unknown tool, or tool execution error.
+    """
+    if _server is None:
+        raise BackendCallError("internal tool backend not registered")
+    try:
+        result = await _server.call_tool(tool_name, arguments)
+    except Exception as exc:
+        logger.warning(
+            "gateway: internal call_tool failed tool=%s err=%s", tool_name, exc
+        )
+        raise BackendCallError(
+            f"internal tool {tool_name!r} call failed: {type(exc).__name__}"
+        ) from exc
+
+    content = [_serialize_content_block(block) for block in result.content]
+    structured = getattr(result, "structured_content", None)
+    return BackendCall(
+        content=content,
+        is_error=bool(getattr(result, "is_error", False)),
+        structured_content=structured if isinstance(structured, dict) else None,
+    )

--- a/src/mcp_airlock_crunchtools/gateway/internal.py
+++ b/src/mcp_airlock_crunchtools/gateway/internal.py
@@ -20,20 +20,17 @@ internal tool and a remote tool present identically to the consumer.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from .backend import BackendCall, _serialize_content_block, _serialize_tool
 from .errors import BackendCallError
 
-if TYPE_CHECKING:
-    from fastmcp import FastMCP
-
 logger = logging.getLogger(__name__)
 
-_server: FastMCP | None = None
+_server: Any = None
 
 
-def register_internal_server(mcp_server: FastMCP) -> None:
+def register_internal_server(mcp_server: Any) -> None:
     """Bind the FastMCP server whose tools the internal backend exposes.
 
     Called once at startup. Idempotent — re-binding simply replaces the

--- a/src/mcp_airlock_crunchtools/gateway/loader.py
+++ b/src/mcp_airlock_crunchtools/gateway/loader.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from pathlib import Path
 from typing import Any
 
@@ -19,6 +20,65 @@ from .errors import ProfileConfigError
 from .profile import Profile
 
 logger = logging.getLogger(__name__)
+
+#: ${VAR} references in backend header values, resolved from the server's own
+#: environment at load time. Lets a profile carry a backend auth header without
+#: hardcoding the secret in YAML (e.g. Authorization: "Bearer ${MCP_MEMORY_API_KEY}").
+_ENV_REF_RE = re.compile(r"\$\{([A-Z_][A-Z0-9_]*)\}")
+
+
+def _expand_env_refs(value: str, *, context: str) -> str:
+    """Substitute ${VAR} references in a header value from os.environ.
+
+    Fails closed (raises ProfileConfigError) if a referenced var is unset or
+    empty — a missing auth secret must not silently become an unauthenticated
+    backend call.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        var_name = match.group(1)
+        resolved = os.environ.get(var_name, "")
+        if not resolved:
+            raise ProfileConfigError(
+                f"{context}: env var {var_name} referenced but not set or empty"
+            )
+        return resolved
+
+    return _ENV_REF_RE.sub(_replace, value)
+
+
+def _build_profile(name: str, body: Any) -> Profile:
+    """Validate one profile entry and resolve its secrets from the environment.
+
+    Resolves the bearer token from `auth.bearer_token_env` and expands any
+    ${VAR} references in backend headers. Both fail closed on a missing env var.
+    """
+    if not isinstance(body, dict):
+        raise ProfileConfigError(
+            f"Profile {name!r}: body must be a mapping, got {type(body).__name__}"
+        )
+    try:
+        profile = Profile(name=name, **body)
+    except ValidationError as exc:
+        raise ProfileConfigError(f"Profile {name!r}: {exc}") from exc
+
+    env_name = profile.auth.bearer_token_env
+    token_value = os.environ.get(env_name, "")
+    if not token_value:
+        raise ProfileConfigError(f"Profile {name!r}: env var {env_name} not set or empty")
+    profile.auth.bearer_token = SecretStr(token_value)
+
+    for backend_name, backend in profile.backends.items():
+        if backend.headers:
+            backend.headers = {
+                key: _expand_env_refs(
+                    val,
+                    context=f"Profile {name!r} backend {backend_name!r} header {key!r}",
+                )
+                for key, val in backend.headers.items()
+            }
+
+    return profile
 
 
 def load_profiles(path: Path | str) -> dict[str, Profile]:
@@ -60,25 +120,9 @@ def load_profiles(path: Path | str) -> dict[str, Profile]:
             f"Profiles file {config_path} must contain a non-empty 'profiles' mapping"
         )
 
-    registry: dict[str, Profile] = {}
-    for name, body in profiles_section.items():
-        if not isinstance(body, dict):
-            raise ProfileConfigError(
-                f"Profile {name!r}: body must be a mapping, got {type(body).__name__}"
-            )
-        try:
-            profile = Profile(name=name, **body)
-        except ValidationError as exc:
-            raise ProfileConfigError(f"Profile {name!r}: {exc}") from exc
-
-        env_name = profile.auth.bearer_token_env
-        token_value = os.environ.get(env_name, "")
-        if not token_value:
-            raise ProfileConfigError(
-                f"Profile {name!r}: env var {env_name} not set or empty"
-            )
-        profile.auth.bearer_token = SecretStr(token_value)
-        registry[name] = profile
+    registry: dict[str, Profile] = {
+        name: _build_profile(name, body) for name, body in profiles_section.items()
+    }
 
     logger.info(
         "gateway: loaded %d profile(s): %s",

--- a/src/mcp_airlock_crunchtools/gateway/loader.py
+++ b/src/mcp_airlock_crunchtools/gateway/loader.py
@@ -1,0 +1,88 @@
+"""YAML profile loader with env-var token resolution.
+
+Fails closed: any missing env var, schema violation, or YAML parse error
+raises `ProfileConfigError` at load time. The server refuses to expose
+gateway routes if loading fails.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import SecretStr, ValidationError
+
+from .errors import ProfileConfigError
+from .profile import Profile
+
+logger = logging.getLogger(__name__)
+
+
+def load_profiles(path: Path | str) -> dict[str, Profile]:
+    """Load profile registry from YAML.
+
+    Args:
+        path: Path to the profiles YAML file.
+
+    Returns:
+        Mapping from profile name to fully-populated `Profile` (bearer tokens
+        resolved from env vars and stored as `SecretStr`).
+
+    Raises:
+        ProfileConfigError: file missing, YAML invalid, schema violated, or
+            an env var named in `auth.bearer_token_env` is unset.
+    """
+    config_path = Path(path)
+    if not config_path.is_file():
+        raise ProfileConfigError(f"Profiles file not found: {config_path}")
+
+    try:
+        raw_text = config_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ProfileConfigError(f"Cannot read profiles file {config_path}: {exc}") from exc
+
+    try:
+        cfg_data: Any = yaml.safe_load(raw_text)
+    except yaml.YAMLError as exc:
+        raise ProfileConfigError(f"Invalid YAML in {config_path}: {exc}") from exc
+
+    if not isinstance(cfg_data, dict):
+        raise ProfileConfigError(
+            f"Profiles file {config_path} must contain a top-level mapping"
+        )
+
+    profiles_section = cfg_data.get("profiles")
+    if not isinstance(profiles_section, dict) or not profiles_section:
+        raise ProfileConfigError(
+            f"Profiles file {config_path} must contain a non-empty 'profiles' mapping"
+        )
+
+    registry: dict[str, Profile] = {}
+    for name, body in profiles_section.items():
+        if not isinstance(body, dict):
+            raise ProfileConfigError(
+                f"Profile {name!r}: body must be a mapping, got {type(body).__name__}"
+            )
+        try:
+            profile = Profile(name=name, **body)
+        except ValidationError as exc:
+            raise ProfileConfigError(f"Profile {name!r}: {exc}") from exc
+
+        env_name = profile.auth.bearer_token_env
+        token_value = os.environ.get(env_name, "")
+        if not token_value:
+            raise ProfileConfigError(
+                f"Profile {name!r}: env var {env_name} not set or empty"
+            )
+        profile.auth.bearer_token = SecretStr(token_value)
+        registry[name] = profile
+
+    logger.info(
+        "gateway: loaded %d profile(s): %s",
+        len(registry),
+        ", ".join(sorted(registry)),
+    )
+    return registry

--- a/src/mcp_airlock_crunchtools/gateway/loader.py
+++ b/src/mcp_airlock_crunchtools/gateway/loader.py
@@ -21,9 +21,6 @@ from .profile import Profile
 
 logger = logging.getLogger(__name__)
 
-#: ${VAR} references in backend header values, resolved from the server's own
-#: environment at load time. Lets a profile carry a backend auth header without
-#: hardcoding the secret in YAML (e.g. Authorization: "Bearer ${MCP_MEMORY_API_KEY}").
 _ENV_REF_RE = re.compile(r"\$\{([A-Z_][A-Z0-9_]*)\}")
 
 

--- a/src/mcp_airlock_crunchtools/gateway/profile.py
+++ b/src/mcp_airlock_crunchtools/gateway/profile.py
@@ -20,6 +20,10 @@ BACKEND_NAME_RE = re.compile(r"^[a-z][a-z0-9-]{0,62}$")
 GLOB_PATTERN_RE = re.compile(r"^[a-zA-Z0-9_*][a-zA-Z0-9_*-]*$")
 ENV_NAME_RE = re.compile(r"^[A-Z_][A-Z0-9_]*$")
 
+#: Scheme marking a backend as airlock's own in-process tool surface rather
+#: than a remote streamable-http MCP server. See gateway/internal.py.
+INTERNAL_SCHEME = "internal://"
+
 MAX_BACKEND_TIMEOUT_SECONDS = 300.0
 
 
@@ -55,7 +59,13 @@ class Backend(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    url: str = Field(..., description="MCP streamable-http URL of the backend")
+    url: str = Field(
+        ...,
+        description=(
+            "Backend location. Either a streamable-http URL (http(s)://) or "
+            "internal://<label> for airlock's own in-process tool surface."
+        ),
+    )
     tools_allow: list[str] = Field(
         default_factory=lambda: ["*"],
         description="Tool-name glob patterns to allow (default: all)",
@@ -77,11 +87,31 @@ class Backend(BaseModel):
 
     @field_validator("url")
     @classmethod
-    def url_is_http_or_https(cls, v: str) -> str:
-        """Restrict the URL scheme to http or https. SSE / stdio not supported."""
-        if not v.startswith(("http://", "https://")):
-            raise ValueError(f"Backend URL must start with http:// or https://: {v!r}")
-        return v
+    def url_scheme_supported(cls, v: str) -> str:
+        """Allow http(s):// (remote MCP) or internal://<label> (airlock's own tools).
+
+        SSE and stdio are not supported. An internal:// URL must carry a
+        URL-safe slug label after the scheme (cosmetic, but required so the
+        namespace stays well-formed).
+        """
+        if v.startswith(("http://", "https://")):
+            return v
+        if v.startswith(INTERNAL_SCHEME):
+            label = v[len(INTERNAL_SCHEME) :]
+            if not BACKEND_NAME_RE.match(label):
+                raise ValueError(
+                    f"internal:// URL must carry a slug label "
+                    f"(^[a-z][a-z0-9-]*$): {v!r}"
+                )
+            return v
+        raise ValueError(
+            f"Backend URL must start with http://, https://, or internal://: {v!r}"
+        )
+
+    @property
+    def is_internal(self) -> bool:
+        """True when this backend resolves to airlock's in-process tool surface."""
+        return self.url.startswith(INTERNAL_SCHEME)
 
     @field_validator("tools_allow", "tools_deny")
     @classmethod

--- a/src/mcp_airlock_crunchtools/gateway/profile.py
+++ b/src/mcp_airlock_crunchtools/gateway/profile.py
@@ -1,0 +1,151 @@
+"""Pydantic v2 models for gateway profile configuration.
+
+Profiles are loaded from YAML and define which backend MCP servers a consumer
+can reach, which tools per backend are allowed, and which defense layers
+apply to responses. Phase 1 stores the defense flags but does not apply
+them — Phase 2 wires the defense pipeline in.
+
+All models use `extra="forbid"` per the constitution; unrecognized keys in
+profile YAML are a hard error at load time.
+"""
+
+from __future__ import annotations
+
+import re
+
+from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_validator
+
+PROFILE_NAME_RE = re.compile(r"^[a-z][a-z0-9-]{0,62}$")
+BACKEND_NAME_RE = re.compile(r"^[a-z][a-z0-9-]{0,62}$")
+GLOB_PATTERN_RE = re.compile(r"^[a-zA-Z0-9_*][a-zA-Z0-9_*-]*$")
+ENV_NAME_RE = re.compile(r"^[A-Z_][A-Z0-9_]*$")
+
+MAX_BACKEND_TIMEOUT_SECONDS = 300.0
+
+
+class AuthConfig(BaseModel):
+    """Per-profile bearer-token auth config.
+
+    `bearer_token_env` is the env var name holding the actual token value;
+    `bearer_token` is resolved at load time and never serialized.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    bearer_token_env: str = Field(
+        ..., description="Env var name whose value is the profile's bearer token"
+    )
+    bearer_token: SecretStr | None = Field(
+        default=None, exclude=True, description="Resolved token (load-time only)"
+    )
+
+    @field_validator("bearer_token_env")
+    @classmethod
+    def env_name_is_uppercase_identifier(cls, v: str) -> str:
+        """Reject lowercase, leading digits, or non-identifier characters."""
+        if not ENV_NAME_RE.match(v):
+            raise ValueError(
+                f"bearer_token_env {v!r} must be an UPPERCASE env-var identifier"
+            )
+        return v
+
+
+class Backend(BaseModel):
+    """Per-profile backend MCP server config."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    url: str = Field(..., description="MCP streamable-http URL of the backend")
+    tools_allow: list[str] = Field(
+        default_factory=lambda: ["*"],
+        description="Tool-name glob patterns to allow (default: all)",
+    )
+    tools_deny: list[str] = Field(
+        default_factory=list,
+        description="Tool-name glob patterns to deny (wins over tools_allow)",
+    )
+    headers: dict[str, str] = Field(
+        default_factory=dict,
+        description="Extra HTTP headers to send to the backend",
+    )
+    timeout_seconds: float = Field(
+        default=30.0,
+        gt=0,
+        le=MAX_BACKEND_TIMEOUT_SECONDS,
+        description="Per-call backend timeout",
+    )
+
+    @field_validator("url")
+    @classmethod
+    def url_is_http_or_https(cls, v: str) -> str:
+        """Restrict the URL scheme to http or https. SSE / stdio not supported."""
+        if not v.startswith(("http://", "https://")):
+            raise ValueError(f"Backend URL must start with http:// or https://: {v!r}")
+        return v
+
+    @field_validator("tools_allow", "tools_deny")
+    @classmethod
+    def glob_patterns_valid(cls, v: list[str]) -> list[str]:
+        """Each glob must match GLOB_PATTERN_RE — restricted character set, no regex metachars."""
+        for pat in v:
+            if not GLOB_PATTERN_RE.match(pat):
+                raise ValueError(
+                    f"Invalid glob pattern {pat!r}: allowed characters are "
+                    "alphanumerics, underscore, hyphen, and '*'; first character "
+                    "may not be a hyphen"
+                )
+        return v
+
+
+class DefenseConfig(BaseModel):
+    """Per-profile defense-layer toggles. Phase 1 stores them; Phase 2 applies them."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    sanitize: bool = Field(default=True, description="L1 sanitization on responses")
+    classify: bool = Field(default=True, description="L2 Prompt Guard 2 classifier")
+    classify_threshold: float = Field(
+        default=0.5, ge=0.0, le=1.0, description="L2 score above which to flag"
+    )
+    quarantine: bool = Field(
+        default=True,
+        description="L3 quarantined Gemini re-extraction (token-cost control)",
+    )
+    quarantine_threshold: float = Field(
+        default=0.7,
+        ge=0.0,
+        le=1.0,
+        description="L2 score above which to trigger L3 (when quarantine=true)",
+    )
+    audit: bool = Field(default=True, description="Write passthrough rows to SQLite")
+
+
+class Profile(BaseModel):
+    """One consumer profile: name, auth, backends, defense config."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(..., description="Profile name (URL-safe slug)")
+    auth: AuthConfig
+    backends: dict[str, Backend] = Field(
+        default_factory=dict,
+        description="Backend MCP servers reachable from this profile",
+    )
+    defense: DefenseConfig = Field(default_factory=DefenseConfig)
+
+    @field_validator("name")
+    @classmethod
+    def name_matches_re(cls, v: str) -> str:
+        """Profile name must be a URL-safe slug (matches PROFILE_NAME_RE)."""
+        if not PROFILE_NAME_RE.match(v):
+            raise ValueError(f"Profile name {v!r} must match ^[a-z][a-z0-9-]*$")
+        return v
+
+    @field_validator("backends")
+    @classmethod
+    def backend_names_match_re(cls, v: dict[str, Backend]) -> dict[str, Backend]:
+        """Each backend dict key must be a URL-safe slug (matches BACKEND_NAME_RE)."""
+        for name in v:
+            if not BACKEND_NAME_RE.match(name):
+                raise ValueError(f"Backend name {name!r} must match ^[a-z][a-z0-9-]*$")
+        return v

--- a/src/mcp_airlock_crunchtools/gateway/profile.py
+++ b/src/mcp_airlock_crunchtools/gateway/profile.py
@@ -20,8 +20,6 @@ BACKEND_NAME_RE = re.compile(r"^[a-z][a-z0-9-]{0,62}$")
 GLOB_PATTERN_RE = re.compile(r"^[a-zA-Z0-9_*][a-zA-Z0-9_*-]*$")
 ENV_NAME_RE = re.compile(r"^[A-Z_][A-Z0-9_]*$")
 
-#: Scheme marking a backend as airlock's own in-process tool surface rather
-#: than a remote streamable-http MCP server. See gateway/internal.py.
 INTERNAL_SCHEME = "internal://"
 
 MAX_BACKEND_TIMEOUT_SECONDS = 300.0

--- a/src/mcp_airlock_crunchtools/gateway/router.py
+++ b/src/mcp_airlock_crunchtools/gateway/router.py
@@ -18,9 +18,11 @@ inserts the L1/L2/L3 defense pipeline here.
 from __future__ import annotations
 
 import logging
+import time
 from typing import TYPE_CHECKING, Any
 
 from .. import __version__
+from ..database import record_gateway_call
 from .backend import call_backend_tool, list_backend_tools
 from .errors import BackendCallError, BackendNotInProfileError
 from .filter import filter_tools
@@ -170,6 +172,7 @@ async def _route_tools_call(
             f"Tool {tool_name!r} not permitted on backend {backend_name!r}",
         )
 
+    t0 = time.monotonic()
     try:
         if backend.is_internal:
             call_result = await call_internal_tool(tool_name, arguments)
@@ -178,7 +181,12 @@ async def _route_tools_call(
                 backend_name, backend, tool_name, arguments
             )
     except BackendCallError as exc:
+        duration_ms = int((time.monotonic() - t0) * 1000)
+        record_gateway_call(profile.name, backend_name, tool_name, False, duration_ms, str(exc))
         return _err(req_id, -32603, str(exc))
+
+    duration_ms = int((time.monotonic() - t0) * 1000)
+    record_gateway_call(profile.name, backend_name, tool_name, True, duration_ms)
 
     result: dict[str, Any] = {
         "content": call_result.content,

--- a/src/mcp_airlock_crunchtools/gateway/router.py
+++ b/src/mcp_airlock_crunchtools/gateway/router.py
@@ -24,6 +24,7 @@ from .. import __version__
 from .backend import call_backend_tool, list_backend_tools
 from .errors import BackendCallError, BackendNotInProfileError
 from .filter import filter_tools
+from .internal import call_internal_tool, list_internal_tools
 
 if TYPE_CHECKING:
     from .profile import Profile
@@ -112,7 +113,10 @@ async def _route_tools_list(profile: Profile, req_id: Any) -> dict[str, Any]:
     aggregated: list[dict[str, Any]] = []
     for backend_name, backend in profile.backends.items():
         try:
-            backend_tools = await list_backend_tools(backend_name, backend)
+            if backend.is_internal:
+                backend_tools = await list_internal_tools()
+            else:
+                backend_tools = await list_backend_tools(backend_name, backend)
         except BackendCallError as exc:
             logger.warning(
                 "gateway: tools/list profile=%s backend=%s skipped: %s",
@@ -167,7 +171,12 @@ async def _route_tools_call(
         )
 
     try:
-        call_result = await call_backend_tool(backend_name, backend, tool_name, arguments)
+        if backend.is_internal:
+            call_result = await call_internal_tool(tool_name, arguments)
+        else:
+            call_result = await call_backend_tool(
+                backend_name, backend, tool_name, arguments
+            )
     except BackendCallError as exc:
         return _err(req_id, -32603, str(exc))
 

--- a/src/mcp_airlock_crunchtools/gateway/router.py
+++ b/src/mcp_airlock_crunchtools/gateway/router.py
@@ -1,0 +1,180 @@
+"""JSON-RPC dispatch for gateway endpoints.
+
+Implements the MCP wire-protocol surface a consumer needs from the gateway:
+`initialize`, `tools/list`, `tools/call`, `ping`, and the
+`notifications/initialized` no-op. Other methods return JSON-RPC error
+-32601 (method not found).
+
+For `tools/list`, aggregates across all backends in the profile and applies
+the allowlist filter. Tool names in the response are namespaced as
+`<backend>__<tool>` to avoid collisions across backends.
+
+For `tools/call`, parses the namespaced tool name back into (backend, tool),
+verifies the backend is in the profile, re-checks the allowlist (defense in
+depth), and forwards. Phase 1 returns the backend response verbatim; Phase 2
+inserts the L1/L2/L3 defense pipeline here.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from .. import __version__
+from .backend import call_backend_tool, list_backend_tools
+from .errors import BackendCallError, BackendNotInProfileError
+from .filter import filter_tools
+
+if TYPE_CHECKING:
+    from .profile import Profile
+
+logger = logging.getLogger(__name__)
+
+PROTOCOL_VERSION = "2024-11-05"
+NAMESPACE_SEP = "__"
+
+
+def _ok(req_id: Any, result: dict[str, Any]) -> dict[str, Any]:
+    """Build a JSON-RPC 2.0 success response."""
+    return {"jsonrpc": "2.0", "id": req_id, "result": result}
+
+
+def _err(req_id: Any, code: int, message: str) -> dict[str, Any]:
+    """Build a JSON-RPC 2.0 error response."""
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "error": {"code": code, "message": message},
+    }
+
+
+async def route_jsonrpc(profile: Profile, request: dict[str, Any]) -> dict[str, Any]:
+    """Dispatch one JSON-RPC request against a profile.
+
+    The response is always a JSON-RPC 2.0 body. HTTP status is 200 for any
+    well-formed JSON-RPC, including error responses — the caller never
+    promotes a JSON-RPC error to an HTTP non-200.
+
+    Args:
+        profile: The authenticated profile (auth was checked before dispatch).
+        request: Parsed JSON-RPC 2.0 request body.
+
+    Returns:
+        JSON-RPC 2.0 response body.
+
+    Raises:
+        BackendNotInProfileError: tools/call targets a backend not present in
+            the profile. The caller maps this to a JSON-RPC error -32602.
+    """
+    method = request.get("method", "")
+    req_id = request.get("id")
+    params = request.get("params") or {}
+
+    if method == "initialize":
+        return _ok(
+            req_id,
+            {
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities": {"tools": {"listChanged": False}},
+                "serverInfo": {
+                    "name": f"mcp-airlock-gateway:{profile.name}",
+                    "version": __version__,
+                },
+                "instructions": (
+                    f"airlock gateway, profile={profile.name}. Tool names are "
+                    f"namespaced as <backend>{NAMESPACE_SEP}<tool>."
+                ),
+            },
+        )
+
+    if method == "ping":
+        return _ok(req_id, {})
+
+    if method == "notifications/initialized":
+        return _ok(req_id, {})
+
+    if method == "tools/list":
+        return await _route_tools_list(profile, req_id)
+
+    if method == "tools/call":
+        return await _route_tools_call(profile, req_id, params)
+
+    return _err(req_id, -32601, f"Method not found: {method}")
+
+
+async def _route_tools_list(profile: Profile, req_id: Any) -> dict[str, Any]:
+    """Aggregate tools/list across the profile's backends, filtered and namespaced.
+
+    A failing backend (down, timing out, refusing) is logged and skipped so
+    the rest of the fleet stays usable. The consumer still sees the union
+    of healthy backends.
+    """
+    aggregated: list[dict[str, Any]] = []
+    for backend_name, backend in profile.backends.items():
+        try:
+            backend_tools = await list_backend_tools(backend_name, backend)
+        except BackendCallError as exc:
+            logger.warning(
+                "gateway: tools/list profile=%s backend=%s skipped: %s",
+                profile.name,
+                backend_name,
+                exc,
+            )
+            continue
+        filtered = filter_tools(backend_tools, backend)
+        for tool in filtered:
+            namespaced_tool = dict(tool)
+            namespaced_tool["name"] = f"{backend_name}{NAMESPACE_SEP}{tool['name']}"
+            aggregated.append(namespaced_tool)
+
+    return _ok(req_id, {"tools": aggregated})
+
+
+async def _route_tools_call(
+    profile: Profile, req_id: Any, params: dict[str, Any]
+) -> dict[str, Any]:
+    """Parse the namespaced tool name, validate routing, forward to the backend.
+
+    Re-applies the allowlist on call as defense in depth: even if a consumer
+    somehow learned about a tool name, calling it must still match the filter
+    that produced their tools/list view.
+    """
+    namespaced_name = params.get("name", "")
+    arguments = params.get("arguments") or {}
+
+    if NAMESPACE_SEP not in namespaced_name:
+        return _err(
+            req_id,
+            -32602,
+            f"Tool name {namespaced_name!r} must be <backend>{NAMESPACE_SEP}<tool>",
+        )
+
+    backend_name, _, tool_name = namespaced_name.partition(NAMESPACE_SEP)
+    if not tool_name:
+        return _err(req_id, -32602, f"Empty tool component in {namespaced_name!r}")
+
+    backend = profile.backends.get(backend_name)
+    if backend is None:
+        raise BackendNotInProfileError(
+            f"backend {backend_name!r} not in profile {profile.name!r}"
+        )
+
+    if not filter_tools([{"name": tool_name}], backend):
+        return _err(
+            req_id,
+            -32602,
+            f"Tool {tool_name!r} not permitted on backend {backend_name!r}",
+        )
+
+    try:
+        call_result = await call_backend_tool(backend_name, backend, tool_name, arguments)
+    except BackendCallError as exc:
+        return _err(req_id, -32603, str(exc))
+
+    result: dict[str, Any] = {
+        "content": call_result.content,
+        "isError": call_result.is_error,
+    }
+    if call_result.structured_content is not None:
+        result["structuredContent"] = call_result.structured_content
+    return _ok(req_id, result)

--- a/src/mcp_airlock_crunchtools/gateway/router.py
+++ b/src/mcp_airlock_crunchtools/gateway/router.py
@@ -17,6 +17,7 @@ inserts the L1/L2/L3 defense pipeline here.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import time
 from typing import TYPE_CHECKING, Any
@@ -35,6 +36,18 @@ logger = logging.getLogger(__name__)
 
 PROTOCOL_VERSION = "2024-11-05"
 NAMESPACE_SEP = "__"
+
+
+def _audit(
+    profile: str,
+    backend: str,
+    tool: str,
+    success: bool,
+    duration_ms: int,
+    error_message: str | None = None,
+) -> None:
+    with contextlib.suppress(Exception):
+        record_gateway_call(profile, backend, tool, success, duration_ms, error_message)
 
 
 def _ok(req_id: Any, result: dict[str, Any]) -> dict[str, Any]:
@@ -182,11 +195,11 @@ async def _route_tools_call(
             )
     except BackendCallError as exc:
         duration_ms = int((time.monotonic() - t0) * 1000)
-        record_gateway_call(profile.name, backend_name, tool_name, False, duration_ms, str(exc))
+        _audit(profile.name, backend_name, tool_name, False, duration_ms, str(exc))
         return _err(req_id, -32603, str(exc))
 
     duration_ms = int((time.monotonic() - t0) * 1000)
-    record_gateway_call(profile.name, backend_name, tool_name, True, duration_ms)
+    _audit(profile.name, backend_name, tool_name, True, duration_ms)
 
     result: dict[str, Any] = {
         "content": call_result.content,

--- a/src/mcp_airlock_crunchtools/server.py
+++ b/src/mcp_airlock_crunchtools/server.py
@@ -24,7 +24,7 @@ from .tools import (
 
 mcp = FastMCP(
     "mcp-airlock-crunchtools",
-    version="0.3.0",
+    version="0.4.0",
     instructions=(
         "Quarantined web content extraction with three-layer prompt injection defense. "
         "Layer 1: deterministic sanitization. Layer 2: Prompt Guard 2 classifier. "

--- a/src/mcp_airlock_crunchtools/server.py
+++ b/src/mcp_airlock_crunchtools/server.py
@@ -24,7 +24,7 @@ from .tools import (
 
 mcp = FastMCP(
     "mcp-airlock-crunchtools",
-    version="0.2.2",
+    version="0.3.0",
     instructions=(
         "Quarantined web content extraction with three-layer prompt injection defense. "
         "Layer 1: deterministic sanitization. Layer 2: Prompt Guard 2 classifier. "

--- a/src/mcp_airlock_crunchtools/tools/stats.py
+++ b/src/mcp_airlock_crunchtools/tools/stats.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from ..config import get_config
-from ..database import get_blocklist_stats
+from ..database import get_blocklist_stats, get_gateway_call_stats
 from ..quarantine.classifier import is_classifier_available
 
 
@@ -30,4 +30,5 @@ async def get_airlock_stats() -> dict[str, Any]:
             "threshold": config.classifier_threshold,
         },
         "blocklist": blocklist,
+        "gateway_audit": get_gateway_call_stats(days=30),
     }

--- a/tests/test_gateway_app.py
+++ b/tests/test_gateway_app.py
@@ -30,32 +30,32 @@ class TestGatewayApp:
     """Endpoint behaviour across auth, body parsing, methods, and dispatch."""
 
     def test_post_unknown_profile_404(self, client: TestClient) -> None:
-        resp = client.post("/gateway/missing/mcp", json={"jsonrpc": "2.0", "id": 1})
+        resp = client.post("/missing/mcp", json={"jsonrpc": "2.0", "id": 1})
         assert resp.status_code == 404
 
     def test_post_missing_auth_401(self, client: TestClient) -> None:
-        resp = client.post("/gateway/alice/mcp", json={"jsonrpc": "2.0", "id": 1})
+        resp = client.post("/alice/mcp", json={"jsonrpc": "2.0", "id": 1})
         assert resp.status_code == 401
 
     def test_post_wrong_token_401(self, client: TestClient) -> None:
         resp = client.post(
-            "/gateway/alice/mcp",
+            "/alice/mcp",
             json={"jsonrpc": "2.0", "id": 1, "method": "ping"},
             headers={"Authorization": "Bearer wrong"},
         )
         assert resp.status_code == 401
 
     def test_get_returns_405(self, client: TestClient) -> None:
-        resp = client.get("/gateway/alice/mcp")
+        resp = client.get("/alice/mcp")
         assert resp.status_code == 405
 
     def test_delete_returns_405(self, client: TestClient) -> None:
-        resp = client.delete("/gateway/alice/mcp")
+        resp = client.delete("/alice/mcp")
         assert resp.status_code == 405
 
     def test_empty_body_400(self, client: TestClient) -> None:
         resp = client.post(
-            "/gateway/alice/mcp",
+            "/alice/mcp",
             content=b"",
             headers={
                 "Authorization": "Bearer alice-token",
@@ -66,7 +66,7 @@ class TestGatewayApp:
 
     def test_invalid_json_400(self, client: TestClient) -> None:
         resp = client.post(
-            "/gateway/alice/mcp",
+            "/alice/mcp",
             content=b"{not json",
             headers={
                 "Authorization": "Bearer alice-token",
@@ -77,7 +77,7 @@ class TestGatewayApp:
 
     def test_non_object_body_400(self, client: TestClient) -> None:
         resp = client.post(
-            "/gateway/alice/mcp",
+            "/alice/mcp",
             json=[1, 2, 3],
             headers={"Authorization": "Bearer alice-token"},
         )
@@ -85,7 +85,7 @@ class TestGatewayApp:
 
     def test_ping_authorized_returns_200(self, client: TestClient) -> None:
         resp = client.post(
-            "/gateway/alice/mcp",
+            "/alice/mcp",
             json={"jsonrpc": "2.0", "id": 5, "method": "ping"},
             headers={"Authorization": "Bearer alice-token"},
         )
@@ -94,7 +94,7 @@ class TestGatewayApp:
 
     def test_initialize_authorized_returns_server_info(self, client: TestClient) -> None:
         resp = client.post(
-            "/gateway/alice/mcp",
+            "/alice/mcp",
             json={"jsonrpc": "2.0", "id": 1, "method": "initialize"},
             headers={"Authorization": "Bearer alice-token"},
         )
@@ -106,7 +106,7 @@ class TestGatewayApp:
         self, client: TestClient
     ) -> None:
         resp = client.post(
-            "/gateway/alice/mcp",
+            "/alice/mcp",
             json={
                 "jsonrpc": "2.0",
                 "id": 9,
@@ -135,7 +135,7 @@ class TestGatewayApp:
             side_effect=fake_call,
         ):
             resp = client.post(
-                "/gateway/alice/mcp",
+                "/alice/mcp",
                 json={
                     "jsonrpc": "2.0",
                     "id": 10,

--- a/tests/test_gateway_app.py
+++ b/tests/test_gateway_app.py
@@ -1,0 +1,154 @@
+"""Tests for gateway/app.py — Starlette routes end-to-end."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from pydantic import SecretStr
+from starlette.testclient import TestClient
+
+from mcp_airlock_crunchtools.gateway.app import gateway_app
+from mcp_airlock_crunchtools.gateway.backend import BackendCall
+from mcp_airlock_crunchtools.gateway.profile import AuthConfig, Backend, Profile
+from mcp_airlock_crunchtools.gateway.router import NAMESPACE_SEP
+
+
+@pytest.fixture
+def client() -> TestClient:
+    """Build a TestClient over a one-profile registry for endpoint-level tests."""
+    profile = Profile(
+        name="alice",
+        auth=AuthConfig(bearer_token_env="A"),
+        backends={"mcp-slack": Backend(url="http://mcp-slack:8005/mcp")},
+    )
+    profile.auth.bearer_token = SecretStr("alice-token")
+    return TestClient(gateway_app({"alice": profile}))
+
+
+class TestGatewayApp:
+    """Endpoint behaviour across auth, body parsing, methods, and dispatch."""
+
+    def test_post_unknown_profile_404(self, client: TestClient) -> None:
+        resp = client.post("/gateway/missing/mcp", json={"jsonrpc": "2.0", "id": 1})
+        assert resp.status_code == 404
+
+    def test_post_missing_auth_401(self, client: TestClient) -> None:
+        resp = client.post("/gateway/alice/mcp", json={"jsonrpc": "2.0", "id": 1})
+        assert resp.status_code == 401
+
+    def test_post_wrong_token_401(self, client: TestClient) -> None:
+        resp = client.post(
+            "/gateway/alice/mcp",
+            json={"jsonrpc": "2.0", "id": 1, "method": "ping"},
+            headers={"Authorization": "Bearer wrong"},
+        )
+        assert resp.status_code == 401
+
+    def test_get_returns_405(self, client: TestClient) -> None:
+        resp = client.get("/gateway/alice/mcp")
+        assert resp.status_code == 405
+
+    def test_delete_returns_405(self, client: TestClient) -> None:
+        resp = client.delete("/gateway/alice/mcp")
+        assert resp.status_code == 405
+
+    def test_empty_body_400(self, client: TestClient) -> None:
+        resp = client.post(
+            "/gateway/alice/mcp",
+            content=b"",
+            headers={
+                "Authorization": "Bearer alice-token",
+                "Content-Type": "application/json",
+            },
+        )
+        assert resp.status_code == 400
+
+    def test_invalid_json_400(self, client: TestClient) -> None:
+        resp = client.post(
+            "/gateway/alice/mcp",
+            content=b"{not json",
+            headers={
+                "Authorization": "Bearer alice-token",
+                "Content-Type": "application/json",
+            },
+        )
+        assert resp.status_code == 400
+
+    def test_non_object_body_400(self, client: TestClient) -> None:
+        resp = client.post(
+            "/gateway/alice/mcp",
+            json=[1, 2, 3],
+            headers={"Authorization": "Bearer alice-token"},
+        )
+        assert resp.status_code == 400
+
+    def test_ping_authorized_returns_200(self, client: TestClient) -> None:
+        resp = client.post(
+            "/gateway/alice/mcp",
+            json={"jsonrpc": "2.0", "id": 5, "method": "ping"},
+            headers={"Authorization": "Bearer alice-token"},
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"jsonrpc": "2.0", "id": 5, "result": {}}
+
+    def test_initialize_authorized_returns_server_info(self, client: TestClient) -> None:
+        resp = client.post(
+            "/gateway/alice/mcp",
+            json={"jsonrpc": "2.0", "id": 1, "method": "initialize"},
+            headers={"Authorization": "Bearer alice-token"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["result"]["serverInfo"]["name"] == "mcp-airlock-gateway:alice"
+
+    def test_tools_call_invalid_backend_returns_jsonrpc_error(
+        self, client: TestClient
+    ) -> None:
+        resp = client.post(
+            "/gateway/alice/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 9,
+                "method": "tools/call",
+                "params": {
+                    "name": f"mcp-not-in-profile{NAMESPACE_SEP}whatever",
+                    "arguments": {},
+                },
+            },
+            headers={"Authorization": "Bearer alice-token"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["error"]["code"] == -32602
+
+    def test_tools_call_happy_path_with_mocked_backend(self, client: TestClient) -> None:
+        async def fake_call(*_args: object, **_kw: object) -> BackendCall:
+            return BackendCall(
+                content=[{"type": "text", "text": "channels: [#general]"}],
+                is_error=False,
+                structured_content=None,
+            )
+
+        with patch(
+            "mcp_airlock_crunchtools.gateway.router.call_backend_tool",
+            side_effect=fake_call,
+        ):
+            resp = client.post(
+                "/gateway/alice/mcp",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 10,
+                    "method": "tools/call",
+                    "params": {
+                        "name": f"mcp-slack{NAMESPACE_SEP}slack_list_channels",
+                        "arguments": {"limit": 5},
+                    },
+                },
+                headers={"Authorization": "Bearer alice-token"},
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["result"]["isError"] is False
+        assert body["result"]["content"][0]["text"] == "channels: [#general]"

--- a/tests/test_gateway_auth.py
+++ b/tests/test_gateway_auth.py
@@ -1,0 +1,64 @@
+"""Tests for gateway/auth.py — bearer-token verification."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import SecretStr
+
+from mcp_airlock_crunchtools.gateway.auth import verify_bearer
+from mcp_airlock_crunchtools.gateway.errors import AuthError
+from mcp_airlock_crunchtools.gateway.profile import AuthConfig, Profile
+
+
+def _profile_with_token(value: str) -> Profile:
+    """Build a Profile with a pre-resolved bearer token for test convenience."""
+    p = Profile(name="t", auth=AuthConfig(bearer_token_env="TEST"))
+    p.auth.bearer_token = SecretStr(value)
+    return p
+
+
+class TestVerifyBearer:
+    """Bearer-token verification covers the full set of failure paths."""
+
+    def test_valid_token_passes(self) -> None:
+        p = _profile_with_token("good-token")
+        verify_bearer("Bearer good-token", p)
+
+    def test_missing_header_rejected(self) -> None:
+        p = _profile_with_token("good-token")
+        with pytest.raises(AuthError, match="missing"):
+            verify_bearer(None, p)
+        with pytest.raises(AuthError, match="missing"):
+            verify_bearer("", p)
+
+    def test_malformed_no_scheme(self) -> None:
+        p = _profile_with_token("good-token")
+        with pytest.raises(AuthError, match="malformed"):
+            verify_bearer("good-token", p)
+
+    def test_malformed_wrong_scheme(self) -> None:
+        p = _profile_with_token("good-token")
+        with pytest.raises(AuthError, match="malformed"):
+            verify_bearer("Basic abc123", p)
+
+    def test_malformed_no_token(self) -> None:
+        p = _profile_with_token("good-token")
+        with pytest.raises(AuthError, match="malformed"):
+            verify_bearer("Bearer ", p)
+
+    def test_wrong_token_rejected(self) -> None:
+        p = _profile_with_token("good-token")
+        with pytest.raises(AuthError, match="invalid token"):
+            verify_bearer("Bearer bad-token", p)
+
+    def test_case_insensitive_scheme(self) -> None:
+        p = _profile_with_token("good-token")
+        verify_bearer("bearer good-token", p)
+        verify_bearer("BEARER good-token", p)
+        verify_bearer("BeArEr good-token", p)
+
+    def test_unresolved_profile_token_rejected(self) -> None:
+        """Loader normally guarantees this, but defense-in-depth."""
+        p = Profile(name="t", auth=AuthConfig(bearer_token_env="TEST"))
+        with pytest.raises(AuthError, match="not resolved"):
+            verify_bearer("Bearer x", p)

--- a/tests/test_gateway_filter.py
+++ b/tests/test_gateway_filter.py
@@ -1,0 +1,84 @@
+"""Tests for gateway/filter.py — tools/list allowlist filter."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mcp_airlock_crunchtools.gateway.filter import filter_tools
+from mcp_airlock_crunchtools.gateway.profile import Backend
+
+
+def _tool(name: str) -> dict[str, Any]:
+    """Build a minimal MCP tool dict for testing."""
+    return {"name": name, "description": f"tool {name}", "inputSchema": {}}
+
+
+def _backend(allow: list[str], deny: list[str] | None = None) -> Backend:
+    """Build a Backend with the given allow/deny patterns for testing."""
+    return Backend(url="http://x/mcp", tools_allow=allow, tools_deny=deny or [])
+
+
+def _names(tools: list[dict[str, Any]]) -> list[str]:
+    """Pull out tool names as a list of plain strings for stable sorting."""
+    return sorted(str(t["name"]) for t in tools)
+
+
+class TestFilter:
+    """Filter behaviour across allowlist, denylist, and glob patterns."""
+
+    def test_wildcard_allow_keeps_all(self) -> None:
+        tools = [_tool("a"), _tool("b"), _tool("c")]
+        out = filter_tools(tools, _backend(["*"]))
+        assert _names(out) == ["a", "b", "c"]
+
+    def test_exact_allow_only(self) -> None:
+        tools = [_tool("a"), _tool("b"), _tool("c")]
+        out = filter_tools(tools, _backend(["a", "c"]))
+        assert _names(out) == ["a", "c"]
+
+    def test_prefix_glob_allow(self) -> None:
+        tools = [_tool("get_x"), _tool("get_y"), _tool("delete_z")]
+        out = filter_tools(tools, _backend(["get_*"]))
+        assert _names(out) == ["get_x", "get_y"]
+
+    def test_deny_wins_over_allow(self) -> None:
+        tools = [_tool("delete_post"), _tool("delete_page"), _tool("get_post")]
+        out = filter_tools(tools, _backend(["*"], deny=["delete_*"]))
+        assert _names(out) == ["get_post"]
+
+    def test_specific_deny_with_wildcard_allow(self) -> None:
+        tools = [
+            _tool("send_gmail_message"),
+            _tool("draft_gmail_message"),
+            _tool("list_gmail_labels"),
+        ]
+        out = filter_tools(tools, _backend(["*"], deny=["send_gmail_message"]))
+        assert _names(out) == ["draft_gmail_message", "list_gmail_labels"]
+
+    def test_empty_allow_keeps_nothing(self) -> None:
+        tools = [_tool("a"), _tool("b")]
+        out = filter_tools(tools, _backend([]))
+        assert out == []
+
+    def test_unnamed_tools_dropped(self) -> None:
+        tools: list[dict[str, Any]] = [{"description": "no name"}, _tool("ok")]
+        out = filter_tools(tools, _backend(["*"]))
+        assert _names(out) == ["ok"]
+
+    def test_combined_patterns(self) -> None:
+        tools = [
+            _tool("wordpress_get_post"),
+            _tool("wordpress_create_post"),
+            _tool("wordpress_update_post"),
+            _tool("wordpress_delete_post"),
+            _tool("wordpress_delete_page"),
+        ]
+        out = filter_tools(
+            tools,
+            _backend(allow=["wordpress_*"], deny=["wordpress_delete_*"]),
+        )
+        assert _names(out) == [
+            "wordpress_create_post",
+            "wordpress_get_post",
+            "wordpress_update_post",
+        ]

--- a/tests/test_gateway_internal.py
+++ b/tests/test_gateway_internal.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Iterator
 from typing import Any
 
 import pytest
-from mcp.types import TextContent
+from mcp.types import TextContent, ToolAnnotations
 from mcp.types import Tool as McpTool
 
 from mcp_airlock_crunchtools.gateway import internal
@@ -112,6 +113,23 @@ class TestInternalBackend:
         sample = tools[0]
         assert "description" in sample
         assert sample["inputSchema"] == {"type": "object", "properties": {}}
+
+    async def test_tools_with_annotations_serialize_to_json(self) -> None:
+        """Regression: a tool whose annotations is a pydantic ToolAnnotations
+        model must serialize to a JSON-able dict, not blow up json.dumps."""
+        annotated = _FakeFunctionTool(
+            McpTool(
+                name="safe_fetch_tool",
+                description="d",
+                inputSchema={"type": "object", "properties": {}},
+                annotations=ToolAnnotations(title="Safe Fetch", readOnlyHint=True),
+            )
+        )
+        internal.register_internal_server(_FakeServer([annotated]))  # type: ignore[arg-type]
+        tools = await internal.list_internal_tools()
+        assert isinstance(tools[0]["annotations"], dict)
+        assert tools[0]["annotations"]["title"] == "Safe Fetch"
+        json.dumps(tools)  # must not raise
 
     async def test_call_returns_backendcall(self) -> None:
         result = _FakeResult(

--- a/tests/test_gateway_internal.py
+++ b/tests/test_gateway_internal.py
@@ -1,0 +1,176 @@
+"""Tests for gateway/internal.py — airlock's own tools as an in-process backend."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from mcp.types import TextContent
+from mcp.types import Tool as McpTool
+
+from mcp_airlock_crunchtools.gateway import internal
+from mcp_airlock_crunchtools.gateway.errors import BackendCallError
+
+
+class _FakeFunctionTool:
+    """Stands in for a FastMCP FunctionTool: only to_mcp_tool() is exercised."""
+
+    def __init__(self, mcp_tool: McpTool) -> None:
+        self._mcp_tool = mcp_tool
+
+    def to_mcp_tool(self) -> McpTool:
+        return self._mcp_tool
+
+
+class _FakeResult:
+    """Stands in for a FastMCP ToolResult."""
+
+    def __init__(
+        self,
+        content: list[Any],
+        structured_content: dict[str, Any] | None = None,
+        is_error: bool = False,
+    ) -> None:
+        self.content = content
+        self.structured_content = structured_content
+        self.is_error = is_error
+
+
+class _FakeServer:
+    """Minimal FastMCP stand-in: list_tools() + call_tool()."""
+
+    name = "fake-airlock"
+
+    def __init__(
+        self,
+        tools: list[_FakeFunctionTool],
+        call_result: _FakeResult | None = None,
+        raise_on_list: Exception | None = None,
+        raise_on_call: Exception | None = None,
+    ) -> None:
+        self._tools = tools
+        self._call_result = call_result
+        self._raise_on_list = raise_on_list
+        self._raise_on_call = raise_on_call
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def list_tools(self) -> list[_FakeFunctionTool]:
+        if self._raise_on_list is not None:
+            raise self._raise_on_list
+        return self._tools
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> _FakeResult:
+        self.calls.append((name, arguments))
+        if self._raise_on_call is not None:
+            raise self._raise_on_call
+        assert self._call_result is not None
+        return self._call_result
+
+
+def _tool(name: str) -> _FakeFunctionTool:
+    return _FakeFunctionTool(
+        McpTool(
+            name=name,
+            description=f"{name} description",
+            inputSchema={"type": "object", "properties": {}},
+        )
+    )
+
+
+@pytest.fixture(autouse=True)
+def _restore_server() -> Iterator[None]:
+    """Save and restore the module-level singleton around every test."""
+    saved = internal._server
+    try:
+        yield
+    finally:
+        internal._server = saved
+
+
+@pytest.mark.asyncio
+class TestInternalBackend:
+    """list/call dispatch against the bound FastMCP server."""
+
+    async def test_not_registered_raises(self) -> None:
+        internal._server = None
+        assert internal.internal_server_registered() is False
+        with pytest.raises(BackendCallError, match="not registered"):
+            await internal.list_internal_tools()
+        with pytest.raises(BackendCallError, match="not registered"):
+            await internal.call_internal_tool("safe_fetch_tool", {})
+
+    async def test_register_then_listed(self) -> None:
+        server = _FakeServer([_tool("safe_fetch_tool"), _tool("quarantine_stats_tool")])
+        internal.register_internal_server(server)  # type: ignore[arg-type]
+        assert internal.internal_server_registered() is True
+
+        tools = await internal.list_internal_tools()
+        names = sorted(t["name"] for t in tools)
+        assert names == ["quarantine_stats_tool", "safe_fetch_tool"]
+        # Serialized shape matches the remote-backend path.
+        sample = tools[0]
+        assert "description" in sample
+        assert sample["inputSchema"] == {"type": "object", "properties": {}}
+
+    async def test_call_returns_backendcall(self) -> None:
+        result = _FakeResult(
+            content=[TextContent(type="text", text="hello")],
+            structured_content={"answer": 42},
+            is_error=False,
+        )
+        server = _FakeServer([_tool("safe_fetch_tool")], call_result=result)
+        internal.register_internal_server(server)  # type: ignore[arg-type]
+
+        call = await internal.call_internal_tool("safe_fetch_tool", {"url": "http://x"})
+        assert server.calls == [("safe_fetch_tool", {"url": "http://x"})]
+        assert call.content == [{"type": "text", "text": "hello"}]
+        assert call.is_error is False
+        assert call.structured_content == {"answer": 42}
+
+    async def test_call_propagates_is_error(self) -> None:
+        result = _FakeResult(
+            content=[TextContent(type="text", text="boom")], is_error=True
+        )
+        server = _FakeServer([_tool("safe_fetch_tool")], call_result=result)
+        internal.register_internal_server(server)  # type: ignore[arg-type]
+
+        call = await internal.call_internal_tool("safe_fetch_tool", {})
+        assert call.is_error is True
+
+    async def test_list_wraps_failure_in_backendcallerror(self) -> None:
+        server = _FakeServer([], raise_on_list=RuntimeError("walk failed"))
+        internal.register_internal_server(server)  # type: ignore[arg-type]
+        with pytest.raises(BackendCallError, match="internal list_tools failed"):
+            await internal.list_internal_tools()
+
+    async def test_call_wraps_failure_in_backendcallerror(self) -> None:
+        server = _FakeServer([], raise_on_call=KeyError("no such tool"))
+        internal.register_internal_server(server)  # type: ignore[arg-type]
+        with pytest.raises(BackendCallError, match="call failed"):
+            await internal.call_internal_tool("nope", {})
+
+
+@pytest.mark.asyncio
+async def test_real_airlock_server_lists_its_tools() -> None:
+    """Integration smoke test: the real FastMCP server's tools serialize cleanly.
+
+    Metadata only — no tool is executed, so this stays offline and DB-free. It
+    guards the to_mcp_tool() path against the installed FastMCP version.
+    """
+    from mcp_airlock_crunchtools.server import mcp
+
+    saved = internal._server
+    try:
+        internal.register_internal_server(mcp)
+        tools = await internal.list_internal_tools()
+    finally:
+        internal._server = saved
+
+    names = {t["name"] for t in tools}
+    assert "safe_fetch_tool" in names
+    assert "quarantine_stats_tool" in names
+    # Every serialized tool carries the fields the gateway namespacer relies on.
+    for t in tools:
+        assert isinstance(t["name"], str) and t["name"]
+        assert "inputSchema" in t

--- a/tests/test_gateway_internal.py
+++ b/tests/test_gateway_internal.py
@@ -103,13 +103,12 @@ class TestInternalBackend:
 
     async def test_register_then_listed(self) -> None:
         server = _FakeServer([_tool("safe_fetch_tool"), _tool("quarantine_stats_tool")])
-        internal.register_internal_server(server)  # type: ignore[arg-type]
+        internal.register_internal_server(server)
         assert internal.internal_server_registered() is True
 
         tools = await internal.list_internal_tools()
         names = sorted(t["name"] for t in tools)
         assert names == ["quarantine_stats_tool", "safe_fetch_tool"]
-        # Serialized shape matches the remote-backend path.
         sample = tools[0]
         assert "description" in sample
         assert sample["inputSchema"] == {"type": "object", "properties": {}}
@@ -125,7 +124,7 @@ class TestInternalBackend:
                 annotations=ToolAnnotations(title="Safe Fetch", readOnlyHint=True),
             )
         )
-        internal.register_internal_server(_FakeServer([annotated]))  # type: ignore[arg-type]
+        internal.register_internal_server(_FakeServer([annotated]))
         tools = await internal.list_internal_tools()
         assert isinstance(tools[0]["annotations"], dict)
         assert tools[0]["annotations"]["title"] == "Safe Fetch"
@@ -138,8 +137,7 @@ class TestInternalBackend:
             is_error=False,
         )
         server = _FakeServer([_tool("safe_fetch_tool")], call_result=result)
-        internal.register_internal_server(server)  # type: ignore[arg-type]
-
+        internal.register_internal_server(server)
         call = await internal.call_internal_tool("safe_fetch_tool", {"url": "http://x"})
         assert server.calls == [("safe_fetch_tool", {"url": "http://x"})]
         assert call.content == [{"type": "text", "text": "hello"}]
@@ -151,20 +149,19 @@ class TestInternalBackend:
             content=[TextContent(type="text", text="boom")], is_error=True
         )
         server = _FakeServer([_tool("safe_fetch_tool")], call_result=result)
-        internal.register_internal_server(server)  # type: ignore[arg-type]
-
+        internal.register_internal_server(server)
         call = await internal.call_internal_tool("safe_fetch_tool", {})
         assert call.is_error is True
 
     async def test_list_wraps_failure_in_backendcallerror(self) -> None:
         server = _FakeServer([], raise_on_list=RuntimeError("walk failed"))
-        internal.register_internal_server(server)  # type: ignore[arg-type]
+        internal.register_internal_server(server)
         with pytest.raises(BackendCallError, match="internal list_tools failed"):
             await internal.list_internal_tools()
 
     async def test_call_wraps_failure_in_backendcallerror(self) -> None:
         server = _FakeServer([], raise_on_call=KeyError("no such tool"))
-        internal.register_internal_server(server)  # type: ignore[arg-type]
+        internal.register_internal_server(server)
         with pytest.raises(BackendCallError, match="call failed"):
             await internal.call_internal_tool("nope", {})
 
@@ -188,7 +185,6 @@ async def test_real_airlock_server_lists_its_tools() -> None:
     names = {t["name"] for t in tools}
     assert "safe_fetch_tool" in names
     assert "quarantine_stats_tool" in names
-    # Every serialized tool carries the fields the gateway namespacer relies on.
     for t in tools:
         assert isinstance(t["name"], str) and t["name"]
         assert "inputSchema" in t

--- a/tests/test_gateway_profile.py
+++ b/tests/test_gateway_profile.py
@@ -65,6 +65,19 @@ class TestProfileModel:
         with pytest.raises(ValidationError):
             Backend(url="ftp://example/mcp")
 
+    def test_internal_url_scheme_accepted(self) -> None:
+        b = Backend(url="internal://web")
+        assert b.is_internal is True
+
+    def test_http_backend_is_not_internal(self) -> None:
+        assert Backend(url="http://x/mcp").is_internal is False
+
+    def test_internal_url_requires_slug_label(self) -> None:
+        with pytest.raises(ValidationError):
+            Backend(url="internal://")
+        with pytest.raises(ValidationError):
+            Backend(url="internal://Bad_Label")
+
     def test_bad_env_name(self) -> None:
         with pytest.raises(ValidationError):
             AuthConfig(bearer_token_env="lowercase_not_allowed")

--- a/tests/test_gateway_profile.py
+++ b/tests/test_gateway_profile.py
@@ -1,0 +1,189 @@
+"""Tests for gateway/profile.py and gateway/loader.py."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from mcp_airlock_crunchtools.gateway.errors import ProfileConfigError
+from mcp_airlock_crunchtools.gateway.loader import load_profiles
+from mcp_airlock_crunchtools.gateway.profile import (
+    AuthConfig,
+    Backend,
+    DefenseConfig,
+    Profile,
+)
+
+
+class TestProfileModel:
+    """Pydantic-level unit tests for Profile / Backend / DefenseConfig."""
+
+    def test_minimal_profile_valid(self) -> None:
+        p = Profile(
+            name="josui",
+            auth=AuthConfig(bearer_token_env="AIRLOCK_PROFILE_JOSUI_TOKEN"),
+        )
+        assert p.name == "josui"
+        assert p.auth.bearer_token_env == "AIRLOCK_PROFILE_JOSUI_TOKEN"
+        assert p.backends == {}
+        assert p.defense.sanitize is True
+        assert p.defense.quarantine is True
+
+    def test_profile_with_backends(self) -> None:
+        p = Profile(
+            name="kagetora",
+            auth=AuthConfig(bearer_token_env="AIRLOCK_PROFILE_KAGETORA_TOKEN"),
+            backends={
+                "mcp-slack": Backend(url="http://mcp-slack:8005/mcp"),
+                "mcp-atlassian": Backend(
+                    url="http://mcp-atlassian:8021/mcp",
+                    tools_deny=["jira_delete_issue"],
+                ),
+            },
+        )
+        assert len(p.backends) == 2
+        assert p.backends["mcp-atlassian"].tools_deny == ["jira_delete_issue"]
+
+    def test_bad_profile_name(self) -> None:
+        with pytest.raises(ValidationError):
+            Profile(
+                name="Has_Underscore",
+                auth=AuthConfig(bearer_token_env="X"),
+            )
+
+    def test_bad_backend_name(self) -> None:
+        with pytest.raises(ValidationError):
+            Profile(
+                name="ok",
+                auth=AuthConfig(bearer_token_env="X"),
+                backends={"BAD_NAME": Backend(url="http://example/mcp")},
+            )
+
+    def test_bad_url_scheme(self) -> None:
+        with pytest.raises(ValidationError):
+            Backend(url="ftp://example/mcp")
+
+    def test_bad_env_name(self) -> None:
+        with pytest.raises(ValidationError):
+            AuthConfig(bearer_token_env="lowercase_not_allowed")
+
+    def test_extra_keys_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            Profile.model_validate(
+                {
+                    "name": "x",
+                    "auth": {"bearer_token_env": "T"},
+                    "extra_unexpected_key": True,
+                }
+            )
+
+    def test_bad_glob_pattern_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            Backend(url="http://x/mcp", tools_allow=["bad/pattern"])
+        with pytest.raises(ValidationError):
+            Backend(url="http://x/mcp", tools_allow=["-leading-hyphen"])
+        with pytest.raises(ValidationError):
+            Backend(url="http://x/mcp", tools_deny=["has space"])
+
+    def test_glob_pattern_allowed(self) -> None:
+        b = Backend(
+            url="http://x/mcp",
+            tools_allow=["*", "delete_*", "get_*_thing", "*_suffix"],
+        )
+        assert "*" in b.tools_allow
+
+    def test_defense_defaults(self) -> None:
+        d = DefenseConfig()
+        assert d.sanitize is True
+        assert d.classify is True
+        assert d.quarantine is True
+        assert d.audit is True
+        assert 0.0 <= d.classify_threshold <= 1.0
+        assert 0.0 <= d.quarantine_threshold <= 1.0
+
+    def test_defense_threshold_bounds(self) -> None:
+        with pytest.raises(ValidationError):
+            DefenseConfig(classify_threshold=1.5)
+        with pytest.raises(ValidationError):
+            DefenseConfig(quarantine_threshold=-0.1)
+
+
+class TestLoader:
+    """End-to-end tests for the YAML profile loader."""
+
+    def test_load_happy_path(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        cfg = tmp_path / "profiles.yaml"
+        cfg.write_text(
+            """
+profiles:
+  josui:
+    auth:
+      bearer_token_env: AIRLOCK_PROFILE_JOSUI_TOKEN
+    backends:
+      mcp-slack:
+        url: http://mcp-slack:8005/mcp
+        tools_allow: ["*"]
+        tools_deny: ["slack_destructive_*"]
+"""
+        )
+        monkeypatch.setenv("AIRLOCK_PROFILE_JOSUI_TOKEN", "tok-josui")
+        registry = load_profiles(cfg)
+        assert set(registry) == {"josui"}
+        token = registry["josui"].auth.bearer_token
+        assert token is not None
+        assert token.get_secret_value() == "tok-josui"
+
+    def test_missing_file(self, tmp_path: Path) -> None:
+        with pytest.raises(ProfileConfigError, match="not found"):
+            load_profiles(tmp_path / "nope.yaml")
+
+    def test_invalid_yaml(self, tmp_path: Path) -> None:
+        cfg = tmp_path / "profiles.yaml"
+        cfg.write_text("not: valid: yaml: [")
+        with pytest.raises(ProfileConfigError, match="Invalid YAML"):
+            load_profiles(cfg)
+
+    def test_top_level_not_a_mapping(self, tmp_path: Path) -> None:
+        cfg = tmp_path / "profiles.yaml"
+        cfg.write_text("- a\n- b\n")
+        with pytest.raises(ProfileConfigError, match="top-level mapping"):
+            load_profiles(cfg)
+
+    def test_missing_profiles_key(self, tmp_path: Path) -> None:
+        cfg = tmp_path / "profiles.yaml"
+        cfg.write_text("other_key: value\n")
+        with pytest.raises(ProfileConfigError, match="non-empty 'profiles'"):
+            load_profiles(cfg)
+
+    def test_missing_token_env(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        cfg = tmp_path / "profiles.yaml"
+        cfg.write_text(
+            """
+profiles:
+  alice:
+    auth:
+      bearer_token_env: NEVER_SET_IN_ENV_FOR_TEST_123
+"""
+        )
+        monkeypatch.delenv("NEVER_SET_IN_ENV_FOR_TEST_123", raising=False)
+        with pytest.raises(ProfileConfigError, match="not set or empty"):
+            load_profiles(cfg)
+
+    def test_extra_key_in_yaml_rejected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cfg = tmp_path / "profiles.yaml"
+        cfg.write_text(
+            """
+profiles:
+  alice:
+    auth:
+      bearer_token_env: TEST_TOK
+    unknown_field: oops
+"""
+        )
+        monkeypatch.setenv("TEST_TOK", "x")
+        with pytest.raises(ProfileConfigError):
+            load_profiles(cfg)

--- a/tests/test_gateway_profile.py
+++ b/tests/test_gateway_profile.py
@@ -170,6 +170,53 @@ profiles:
         with pytest.raises(ProfileConfigError, match="non-empty 'profiles'"):
             load_profiles(cfg)
 
+    def test_header_env_ref_expanded(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cfg = tmp_path / "profiles.yaml"
+        cfg.write_text(
+            """
+profiles:
+  kagetora:
+    auth:
+      bearer_token_env: AIRLOCK_PROFILE_KAGETORA_TOKEN
+    backends:
+      memory:
+        url: http://mcp-memory:8765/mcp
+        headers:
+          Authorization: "Bearer ${MCP_MEMORY_API_KEY}"
+"""
+        )
+        monkeypatch.setenv("AIRLOCK_PROFILE_KAGETORA_TOKEN", "tok")
+        monkeypatch.setenv("MCP_MEMORY_API_KEY", "memsecret")
+        registry = load_profiles(cfg)
+        assert (
+            registry["kagetora"].backends["memory"].headers["Authorization"]
+            == "Bearer memsecret"
+        )
+
+    def test_header_env_ref_missing_fails_closed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cfg = tmp_path / "profiles.yaml"
+        cfg.write_text(
+            """
+profiles:
+  kagetora:
+    auth:
+      bearer_token_env: AIRLOCK_PROFILE_KAGETORA_TOKEN
+    backends:
+      memory:
+        url: http://mcp-memory:8765/mcp
+        headers:
+          Authorization: "Bearer ${MCP_MEMORY_API_KEY}"
+"""
+        )
+        monkeypatch.setenv("AIRLOCK_PROFILE_KAGETORA_TOKEN", "tok")
+        monkeypatch.delenv("MCP_MEMORY_API_KEY", raising=False)
+        with pytest.raises(ProfileConfigError, match="MCP_MEMORY_API_KEY"):
+            load_profiles(cfg)
+
     def test_missing_token_env(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         cfg = tmp_path / "profiles.yaml"
         cfg.write_text(

--- a/tests/test_gateway_router.py
+++ b/tests/test_gateway_router.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 import pytest
 from pydantic import SecretStr
 
+from mcp_airlock_crunchtools.database import get_gateway_call_stats
 from mcp_airlock_crunchtools.gateway.backend import BackendCall
 from mcp_airlock_crunchtools.gateway.errors import BackendCallError, BackendNotInProfileError
 from mcp_airlock_crunchtools.gateway.profile import AuthConfig, Backend, Profile
@@ -279,3 +280,83 @@ class TestRouter:
         )
         assert resp["error"]["code"] == -32602
         assert "not permitted" in resp["error"]["message"].lower()
+
+    async def test_tools_call_records_audit_on_success(self, tmp_path: Any) -> None:
+        """Successful tools/call writes an audit row to gateway_calls."""
+        import mcp_airlock_crunchtools.database as db_mod
+
+        db_mod._db = None
+        db_path = str(tmp_path / "audit_test.db")
+
+        async def fake_call(
+            _bn: str, _b: Backend, _tn: str, _args: dict[str, Any],
+        ) -> BackendCall:
+            return BackendCall(
+                content=[{"type": "text", "text": "ok"}],
+                is_error=False, structured_content=None,
+            )
+
+        tool_name = f"mcp-slack{NAMESPACE_SEP}slack_list_channels"
+        with (
+            patch(
+                "mcp_airlock_crunchtools.gateway.router.call_backend_tool",
+                side_effect=fake_call,
+            ),
+            patch("mcp_airlock_crunchtools.database.get_config") as mock_cfg,
+        ):
+            mock_cfg.return_value.db_path = db_path
+            mock_cfg.return_value.ensure_db_dir = lambda: None
+            await route_jsonrpc(
+                _profile(),
+                {
+                    "jsonrpc": "2.0",
+                    "id": 20,
+                    "method": "tools/call",
+                    "params": {"name": tool_name, "arguments": {}},
+                },
+            )
+
+        stats = get_gateway_call_stats("testp", days=1)
+        assert stats["total_calls"] == 1
+        assert stats["by_tool"][0]["tool"] == "slack_list_channels"
+        assert stats["by_tool"][0]["ok"] == 1
+        assert stats["by_tool"][0]["errors"] == 0
+        db_mod._db = None
+
+    async def test_tools_call_records_audit_on_failure(self, tmp_path: Any) -> None:
+        """Failed tools/call writes an audit row with error_message."""
+        import mcp_airlock_crunchtools.database as db_mod
+
+        db_mod._db = None
+        db_path = str(tmp_path / "audit_fail_test.db")
+
+        async def fail_call(
+            _bn: str, _b: Backend, _tn: str, _args: dict[str, Any],
+        ) -> BackendCall:
+            raise BackendCallError("backend down")
+
+        tool_name = f"mcp-slack{NAMESPACE_SEP}slack_list_channels"
+        with (
+            patch(
+                "mcp_airlock_crunchtools.gateway.router.call_backend_tool",
+                side_effect=fail_call,
+            ),
+            patch("mcp_airlock_crunchtools.database.get_config") as mock_cfg,
+        ):
+            mock_cfg.return_value.db_path = db_path
+            mock_cfg.return_value.ensure_db_dir = lambda: None
+            resp = await route_jsonrpc(
+                _profile(),
+                {
+                    "jsonrpc": "2.0",
+                    "id": 21,
+                    "method": "tools/call",
+                    "params": {"name": tool_name, "arguments": {}},
+                },
+            )
+
+        assert resp["error"]["code"] == -32603
+        stats = get_gateway_call_stats("testp", days=1)
+        assert stats["total_calls"] == 1
+        assert stats["by_tool"][0]["errors"] == 1
+        db_mod._db = None

--- a/tests/test_gateway_router.py
+++ b/tests/test_gateway_router.py
@@ -39,6 +39,20 @@ def _profile() -> Profile:
     return p
 
 
+def _mixed_profile() -> Profile:
+    """Profile mixing an http backend with an internal:// (airlock-tools) backend."""
+    p = Profile(
+        name="mixed",
+        auth=AuthConfig(bearer_token_env="TEST"),
+        backends={
+            "mcp-slack": Backend(url="http://mcp-slack:8005/mcp", tools_allow=["*"]),
+            "web": Backend(url="internal://web", tools_allow=["*"]),
+        },
+    )
+    p.auth.bearer_token = SecretStr("x")
+    return p
+
+
 @pytest.mark.asyncio
 class TestRouter:
     """JSON-RPC dispatch covers initialize, ping, tools/list, tools/call."""
@@ -169,6 +183,84 @@ class TestRouter:
                     },
                 },
             )
+
+    async def test_tools_list_aggregates_http_and_internal(self) -> None:
+        """Mixed-backend tools/list: http + internal both filtered and namespaced."""
+
+        async def fake_list(_backend_name: str, _backend: Backend) -> list[dict[str, Any]]:
+            return [{"name": "slack_list_channels", "description": "", "inputSchema": {}}]
+
+        async def fake_internal_list() -> list[dict[str, Any]]:
+            return [
+                {"name": "safe_fetch_tool", "description": "", "inputSchema": {}},
+                {"name": "quarantine_stats_tool", "description": "", "inputSchema": {}},
+            ]
+
+        with (
+            patch(
+                "mcp_airlock_crunchtools.gateway.router.list_backend_tools",
+                side_effect=fake_list,
+            ),
+            patch(
+                "mcp_airlock_crunchtools.gateway.router.list_internal_tools",
+                side_effect=fake_internal_list,
+            ),
+        ):
+            resp = await route_jsonrpc(
+                _mixed_profile(), {"jsonrpc": "2.0", "id": 9, "method": "tools/list"}
+            )
+
+        names = sorted(str(t["name"]) for t in resp["result"]["tools"])
+        assert names == [
+            f"mcp-slack{NAMESPACE_SEP}slack_list_channels",
+            f"web{NAMESPACE_SEP}quarantine_stats_tool",
+            f"web{NAMESPACE_SEP}safe_fetch_tool",
+        ]
+
+    async def test_tools_call_routes_to_internal_backend(self) -> None:
+        """A call on the internal backend dispatches to call_internal_tool, not http."""
+        called: dict[str, Any] = {}
+
+        async def fake_internal_call(
+            tool_name: str, arguments: dict[str, Any]
+        ) -> BackendCall:
+            called["tool"] = tool_name
+            called["args"] = arguments
+            return BackendCall(
+                content=[{"type": "text", "text": "fetched"}],
+                is_error=False,
+                structured_content=None,
+            )
+
+        async def fail_http(*_args: Any, **_kwargs: Any) -> BackendCall:
+            raise AssertionError("http backend must not be called for internal://")
+
+        with (
+            patch(
+                "mcp_airlock_crunchtools.gateway.router.call_internal_tool",
+                side_effect=fake_internal_call,
+            ),
+            patch(
+                "mcp_airlock_crunchtools.gateway.router.call_backend_tool",
+                side_effect=fail_http,
+            ),
+        ):
+            resp = await route_jsonrpc(
+                _mixed_profile(),
+                {
+                    "jsonrpc": "2.0",
+                    "id": 10,
+                    "method": "tools/call",
+                    "params": {
+                        "name": f"web{NAMESPACE_SEP}safe_fetch_tool",
+                        "arguments": {"url": "http://example.com"},
+                    },
+                },
+            )
+
+        assert called == {"tool": "safe_fetch_tool", "args": {"url": "http://example.com"}}
+        assert resp["result"]["content"] == [{"type": "text", "text": "fetched"}]
+        assert resp["result"]["isError"] is False
 
     async def test_tools_call_enforces_denylist_at_call_time(self) -> None:
         """Defense in depth: a deny-listed tool name on a valid backend must

--- a/tests/test_gateway_router.py
+++ b/tests/test_gateway_router.py
@@ -1,0 +1,189 @@
+"""Tests for gateway/router.py — JSON-RPC dispatch with mocked backends."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from pydantic import SecretStr
+
+from mcp_airlock_crunchtools.gateway.backend import BackendCall
+from mcp_airlock_crunchtools.gateway.errors import BackendCallError, BackendNotInProfileError
+from mcp_airlock_crunchtools.gateway.profile import AuthConfig, Backend, Profile
+from mcp_airlock_crunchtools.gateway.router import (
+    NAMESPACE_SEP,
+    PROTOCOL_VERSION,
+    route_jsonrpc,
+)
+
+
+def _profile() -> Profile:
+    """Build a Profile with two backends and one deny pattern for testing."""
+    p = Profile(
+        name="testp",
+        auth=AuthConfig(bearer_token_env="TEST"),
+        backends={
+            "mcp-slack": Backend(
+                url="http://mcp-slack:8005/mcp",
+                tools_allow=["*"],
+                tools_deny=["slack_dangerous"],
+            ),
+            "mcp-atlassian": Backend(
+                url="http://mcp-atlassian:8021/mcp",
+                tools_allow=["*"],
+            ),
+        },
+    )
+    p.auth.bearer_token = SecretStr("x")
+    return p
+
+
+@pytest.mark.asyncio
+class TestRouter:
+    """JSON-RPC dispatch covers initialize, ping, tools/list, tools/call."""
+
+    async def test_initialize_returns_server_info(self) -> None:
+        resp = await route_jsonrpc(_profile(), {"jsonrpc": "2.0", "id": 1, "method": "initialize"})
+        assert resp["id"] == 1
+        assert resp["result"]["protocolVersion"] == PROTOCOL_VERSION
+        assert resp["result"]["serverInfo"]["name"] == "mcp-airlock-gateway:testp"
+        assert "tools" in resp["result"]["capabilities"]
+
+    async def test_ping_returns_empty_result(self) -> None:
+        resp = await route_jsonrpc(_profile(), {"jsonrpc": "2.0", "id": 7, "method": "ping"})
+        assert resp == {"jsonrpc": "2.0", "id": 7, "result": {}}
+
+    async def test_unknown_method_returns_method_not_found(self) -> None:
+        resp = await route_jsonrpc(
+            _profile(),
+            {"jsonrpc": "2.0", "id": 2, "method": "resources/list"},
+        )
+        assert resp["error"]["code"] == -32601
+
+    async def test_tools_list_aggregates_and_namespaces(self) -> None:
+        async def fake_list(backend_name: str, _backend: Backend) -> list[dict[str, Any]]:
+            if backend_name == "mcp-slack":
+                return [
+                    {"name": "slack_list_channels", "description": "", "inputSchema": {}},
+                    {"name": "slack_dangerous", "description": "", "inputSchema": {}},
+                ]
+            return [{"name": "jira_search", "description": "", "inputSchema": {}}]
+
+        with patch(
+            "mcp_airlock_crunchtools.gateway.router.list_backend_tools",
+            side_effect=fake_list,
+        ):
+            resp = await route_jsonrpc(
+                _profile(), {"jsonrpc": "2.0", "id": 3, "method": "tools/list"}
+            )
+
+        names = sorted(str(t["name"]) for t in resp["result"]["tools"])
+        assert names == [
+            f"mcp-atlassian{NAMESPACE_SEP}jira_search",
+            f"mcp-slack{NAMESPACE_SEP}slack_list_channels",
+        ]
+
+    async def test_tools_list_skips_unreachable_backend(self) -> None:
+        async def fake_list(backend_name: str, _backend: Backend) -> list[dict[str, Any]]:
+            if backend_name == "mcp-slack":
+                raise BackendCallError("simulated outage")
+            return [{"name": "jira_search", "description": "", "inputSchema": {}}]
+
+        with patch(
+            "mcp_airlock_crunchtools.gateway.router.list_backend_tools",
+            side_effect=fake_list,
+        ):
+            resp = await route_jsonrpc(
+                _profile(), {"jsonrpc": "2.0", "id": 4, "method": "tools/list"}
+            )
+        names = [str(t["name"]) for t in resp["result"]["tools"]]
+        assert names == [f"mcp-atlassian{NAMESPACE_SEP}jira_search"]
+
+    async def test_tools_call_routes_to_correct_backend(self) -> None:
+        called: dict[str, Any] = {}
+
+        async def fake_call(
+            backend_name: str,
+            _backend: Backend,
+            tool_name: str,
+            arguments: dict[str, Any],
+        ) -> BackendCall:
+            called["backend"] = backend_name
+            called["tool"] = tool_name
+            called["args"] = arguments
+            return BackendCall(
+                content=[{"type": "text", "text": "ok"}],
+                is_error=False,
+                structured_content=None,
+            )
+
+        with patch(
+            "mcp_airlock_crunchtools.gateway.router.call_backend_tool",
+            side_effect=fake_call,
+        ):
+            resp = await route_jsonrpc(
+                _profile(),
+                {
+                    "jsonrpc": "2.0",
+                    "id": 5,
+                    "method": "tools/call",
+                    "params": {
+                        "name": f"mcp-slack{NAMESPACE_SEP}slack_list_channels",
+                        "arguments": {"limit": 5},
+                    },
+                },
+            )
+
+        assert called == {
+            "backend": "mcp-slack",
+            "tool": "slack_list_channels",
+            "args": {"limit": 5},
+        }
+        assert resp["result"]["content"] == [{"type": "text", "text": "ok"}]
+        assert resp["result"]["isError"] is False
+
+    async def test_tools_call_rejects_non_namespaced_name(self) -> None:
+        resp = await route_jsonrpc(
+            _profile(),
+            {
+                "jsonrpc": "2.0",
+                "id": 6,
+                "method": "tools/call",
+                "params": {"name": "no_namespace", "arguments": {}},
+            },
+        )
+        assert resp["error"]["code"] == -32602
+
+    async def test_tools_call_rejects_unknown_backend(self) -> None:
+        with pytest.raises(BackendNotInProfileError):
+            await route_jsonrpc(
+                _profile(),
+                {
+                    "jsonrpc": "2.0",
+                    "id": 7,
+                    "method": "tools/call",
+                    "params": {
+                        "name": f"mcp-unknown{NAMESPACE_SEP}some_tool",
+                        "arguments": {},
+                    },
+                },
+            )
+
+    async def test_tools_call_enforces_denylist_at_call_time(self) -> None:
+        """Defense in depth: a deny-listed tool name on a valid backend must
+        be rejected at call time even if the consumer somehow learned the name."""
+        resp = await route_jsonrpc(
+            _profile(),
+            {
+                "jsonrpc": "2.0",
+                "id": 8,
+                "method": "tools/call",
+                "params": {
+                    "name": f"mcp-slack{NAMESPACE_SEP}slack_dangerous",
+                    "arguments": {},
+                },
+            },
+        )
+        assert resp["error"]["code"] == -32602
+        assert "not permitted" in resp["error"]["message"].lower()


### PR DESCRIPTION
## Summary
- Add `gateway_calls` SQLite table that logs every `tools/call` through the gateway (profile, backend, tool, success, duration_ms, error)
- Audit write is fire-and-forget — never breaks a tool call
- Stats exposed via `quarantine_stats_tool` under `gateway_audit` key
- Add `examples/profiles-kagetora.yaml` with tightened allowlists: **~520 → ~195 tools (62% reduction)**

## Kagetora allowlist breakdown

| Backend | Before | After | Notes |
|---------|--------|-------|-------|
| gws-personal | ~130 | 25 | Gmail, Calendar, Tasks, Contacts, Drive read |
| gws-work | ~130 | 15 | Gmail, Calendar, Contacts, Drive read |
| atlassian | ~40 | 14 | Search, read, write, transitions, links |
| gemini | ~25 | 12 | Query, search, image gen, analysis |
| cloudflare | ~20 | 6 | Analytics read-only, no DNS writes |
| wordpress x2 | ~40 | 20 | Posts, media, categories |
| 8 small backends | ~135 | ~135 | Keep `["*"]` — all <20 tools |

## Next steps
- Deploy profile to lotor (config-only, no rebuild)
- After 1-2 months, query `gateway_calls` to prune unused tools
- Separate follow-on: description trimming to reduce per-tool context size

## Test plan
- [x] 337 tests pass (including 2 new audit tests)
- [x] Lint clean (`ruff check`)
- [x] Type check clean (`mypy`)
- [ ] Deploy to lotor and verify `hermes mcp test` shows ~195 tools
- [ ] After 30 days, run `SELECT backend, tool, COUNT(*) FROM gateway_calls GROUP BY backend, tool ORDER BY count DESC`

🤖 Generated with [Claude Code](https://claude.com/claude-code)