### PR TITLE
fix(gateway): non-blocking startup for description compression

### DIFF
--- a/src/mcp_trentina_crunchtools/__init__.py
+++ b/src/mcp_trentina_crunchtools/__init__.py
@@ -7,7 +7,7 @@ import asyncio
 import logging
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 __version__ = "0.5.0"
 
@@ -101,20 +101,19 @@ def _run_with_gateway(mcp_server: FastMCP, *, host: str, port: int) -> None:
 
     load_compression_cache()
 
-    async def _bg_compress() -> None:
+    import threading
+
+    def _bg_compress_thread() -> None:
+        loop = asyncio.new_event_loop()
         try:
-            stats = await precompress_all(registry)
+            stats = loop.run_until_complete(precompress_all(registry))
             if stats:
                 logger.info("gateway: pre-compressed tools: %s", stats)
         except Exception:
             logger.warning("gateway: pre-compression failed", exc_info=True)
+        finally:
+            loop.close()
 
-    original_run = mcp_server.run
+    threading.Thread(target=_bg_compress_thread, daemon=True).start()
 
-    def _run_with_compression(**kwargs: Any) -> None:
-        loop = asyncio.new_event_loop()
-        loop.run_until_complete(_bg_compress())
-        loop.close()
-        original_run(**kwargs)
-
-    _run_with_compression(transport="streamable-http", host=host, port=port)
+    mcp_server.run(transport="streamable-http", host=host, port=port)


### PR DESCRIPTION
## Summary
- Pre-compression was blocking server startup — if backends were slow or the model returned errors, the HTTP server never started listening
- Now runs in a daemon thread so the server starts immediately
- Compressions fill the cache in the background as they complete

Hotfix for the compression feature merged in PR #23.

## Test plan
- [x] 372 tests passing, lint clean
- [x] Verified the blocking behavior on lotor test instance
- [x] Fix confirmed: server starts immediately, compression runs in background

🤖 Generated with [Claude Code](https://claude.com/claude-code)