### PR TITLE
fix(gateway): lazy-trigger description compression on first tools/list

### DIFF
--- a/src/mcp_trentina_crunchtools/__init__.py
+++ b/src/mcp_trentina_crunchtools/__init__.py
@@ -84,7 +84,7 @@ def _run_with_gateway(mcp_server: FastMCP, *, host: str, port: int) -> None:
     no gateway when the operator asked for one.
     """
     from .gateway import load_profiles, register_internal_server, register_with_fastmcp
-    from .gateway.compress import load_compression_cache
+    from .gateway.compress import load_compression_cache, set_profiles
 
     profiles_path = Path(
         os.environ.get("TRENTINA_PROFILES_PATH", "/etc/trentina/profiles.yaml")
@@ -100,10 +100,6 @@ def _run_with_gateway(mcp_server: FastMCP, *, host: str, port: int) -> None:
     )
 
     load_compression_cache()
-
-    # NOTE: Pre-compression at startup is disabled pending #29.
-    # The compress_descriptions profile flag still works for cached
-    # descriptions loaded from SQLite — only the automatic pre-compression
-    # on startup is disabled until the event loop integration is resolved.
+    set_profiles(registry)
 
     mcp_server.run(transport="streamable-http", host=host, port=port)

--- a/src/mcp_trentina_crunchtools/gateway/compress.py
+++ b/src/mcp_trentina_crunchtools/gateway/compress.py
@@ -1,8 +1,9 @@
 """Tool description compression for the gateway.
 
-Pre-compresses verbose tool descriptions at startup using Gemini.
-Results are cached in SQLite and looked up synchronously during tools/list.
-Compression is best-effort: failures at any level are logged and skipped.
+Compresses verbose tool descriptions via Gemini, triggered lazily on the
+first tools/list request.  Results are cached in SQLite and looked up
+synchronously on subsequent calls.  Compression is best-effort: failures
+at any level are logged and skipped.
 """
 
 from __future__ import annotations
@@ -30,8 +31,14 @@ BATCH_SIZE = 5
 DELAY_BETWEEN_BACKENDS = 2
 DELAY_BETWEEN_BATCHES = 3
 DEFAULT_COMPRESS_MODEL = "gemini-2.5-flash-lite"
+MAX_RETRIES = 3
+RETRY_BASE_DELAY = 2.0
+_RETRYABLE_STATUS_CODES = {429, 503}
 
 _cache: dict[str, str] = {}
+_profiles: dict[str, Profile] | None = None
+_compress_triggered: bool = False
+_compress_task: asyncio.Task[dict[str, int]] | None = None
 
 COMPRESS_SYSTEM_PROMPT = """\
 You are a tool description compressor. Given MCP tool descriptions, produce \
@@ -76,6 +83,27 @@ def load_compression_cache() -> int:
     _cache = get_all_compressions()
     logger.info("compress: loaded %d cached compressions from database", len(_cache))
     return len(_cache)
+
+
+def set_profiles(profiles: dict[str, Profile]) -> None:
+    """Store the profile registry for lazy compression."""
+    global _profiles
+    _profiles = profiles
+
+
+async def maybe_trigger_compression() -> None:
+    """Trigger background compression once on the first call.
+
+    Idempotent: subsequent calls return immediately.  The compression
+    task runs on the current event loop (the same one serving tools/list),
+    so streamablehttp_client works without thread gymnastics.
+    """
+    global _compress_triggered, _compress_task
+    if _compress_triggered or _profiles is None:
+        return
+    _compress_triggered = True
+    _compress_task = asyncio.create_task(precompress_all(_profiles))
+    logger.info("compress: background compression triggered by first tools/list")
 
 
 def compress_tools(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -241,19 +269,30 @@ async def _call_compress_model(
         },
     }
 
-    try:
-        async with httpx.AsyncClient(timeout=httpx.Timeout(GEMINI_TIMEOUT)) as client:
-            resp = await client.post(url, json=request_body)
-            resp.raise_for_status()
-            data = resp.json()
-    except httpx.HTTPStatusError as exc:
-        logger.warning("compress: Gemini %d for %d items", exc.response.status_code, len(items))
-        return []
-    except Exception:
-        logger.warning("compress: Gemini call failed for %d items", len(items))
-        return []
+    for attempt in range(MAX_RETRIES):
+        try:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(GEMINI_TIMEOUT)) as client:
+                resp = await client.post(url, json=request_body)
+                resp.raise_for_status()
+                data = resp.json()
+            return _parse_compress_response(data)
+        except httpx.HTTPStatusError as exc:
+            status = exc.response.status_code
+            if status in _RETRYABLE_STATUS_CODES and attempt < MAX_RETRIES - 1:
+                delay = RETRY_BASE_DELAY * (2**attempt)
+                logger.info(
+                    "compress: Gemini %d, retry %d/%d in %.0fs",
+                    status, attempt + 1, MAX_RETRIES, delay,
+                )
+                await asyncio.sleep(delay)
+                continue
+            logger.warning("compress: Gemini %d for %d items", status, len(items))
+            return []
+        except Exception:
+            logger.warning("compress: Gemini call failed for %d items", len(items))
+            return []
 
-    return _parse_compress_response(data)
+    return []
 
 
 def _parse_compress_response(data: dict[str, Any]) -> list[tuple[str, str]]:
@@ -271,7 +310,7 @@ def _parse_compress_response(data: dict[str, Any]) -> list[tuple[str, str]]:
         return []
     except json.JSONDecodeError:
         raw = candidates[0].get("content", {}).get("parts", [{}])[0].get("text", "")
-        logger.warning("compress: malformed JSON from Gemini (len=%d): %.100s", len(raw), raw)
+        logger.warning("compress: malformed JSON from Gemini (len=%d): %.200s", len(raw), raw)
         return []
 
     return [

--- a/src/mcp_trentina_crunchtools/gateway/compress.py
+++ b/src/mcp_trentina_crunchtools/gateway/compress.py
@@ -288,8 +288,8 @@ async def _call_compress_model(
                 continue
             logger.warning("compress: Gemini %d for %d items", status, len(items))
             return []
-        except Exception:
-            logger.warning("compress: Gemini call failed for %d items", len(items))
+        except Exception as exc:
+            logger.warning("compress: Gemini call failed for %d items: %s", len(items), exc)
             return []
 
     return []

--- a/src/mcp_trentina_crunchtools/gateway/router.py
+++ b/src/mcp_trentina_crunchtools/gateway/router.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING, Any
 from .. import __version__
 from ..database import record_gateway_call
 from .backend import call_backend_tool, list_backend_tools
-from .compress import compress_tools
+from .compress import compress_tools, maybe_trigger_compression
 from .errors import BackendCallError, BackendNotInProfileError
 from .filter import filter_tools
 from .guards import check_parameter_guards
@@ -127,6 +127,7 @@ async def _route_tools_list(profile: Profile, req_id: Any) -> dict[str, Any]:
     the rest of the fleet stays usable. The consumer still sees the union
     of healthy backends.
     """
+    await maybe_trigger_compression()
     aggregated: list[dict[str, Any]] = []
     for backend_name, backend in profile.backends.items():
         try:

--- a/tests/test_gateway_compress.py
+++ b/tests/test_gateway_compress.py
@@ -10,12 +10,15 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
+from mcp_trentina_crunchtools.gateway import compress as compress_mod
 from mcp_trentina_crunchtools.gateway.compress import (
     _cache,
     _call_compress_model,
     _hash_description,
     _precompress_backend,
     compress_tools,
+    maybe_trigger_compression,
+    set_profiles,
 )
 
 
@@ -275,3 +278,187 @@ class TestPrecompressBackend:
 
         assert count == 0
         assert _hash_description(original) not in _cache
+
+
+class TestMaybeTriggerCompression:
+    """Tests for the lazy compression trigger."""
+
+    def setup_method(self) -> None:
+        _cache.clear()
+        compress_mod._compress_triggered = False
+        compress_mod._compress_task = None
+        compress_mod._profiles = None
+
+    @pytest.mark.asyncio
+    async def test_triggers_once_only(self) -> None:
+        from mcp_trentina_crunchtools.gateway.profile import AuthConfig, Backend, Profile
+
+        auth = AuthConfig(bearer_token_env="TEST_TOKEN")
+        profile = Profile(
+            name="test",
+            auth=auth,
+            backends={"b": Backend(url="http://x:8000/mcp", compress_descriptions=True)},
+        )
+        set_profiles({"test": profile})
+
+        with patch(
+            "mcp_trentina_crunchtools.gateway.compress.precompress_all",
+            new_callable=AsyncMock,
+            return_value={},
+        ) as mock_precompress:
+            await maybe_trigger_compression()
+            await maybe_trigger_compression()
+
+        mock_precompress.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_no_profiles_is_noop(self) -> None:
+        compress_mod._profiles = None
+        with patch(
+            "mcp_trentina_crunchtools.gateway.compress.precompress_all",
+            new_callable=AsyncMock,
+        ) as mock_precompress:
+            await maybe_trigger_compression()
+
+        mock_precompress.assert_not_called()
+        assert not compress_mod._compress_triggered
+
+    @pytest.mark.asyncio
+    async def test_creates_background_task(self) -> None:
+        from mcp_trentina_crunchtools.gateway.profile import AuthConfig, Backend, Profile
+
+        auth = AuthConfig(bearer_token_env="TEST_TOKEN")
+        profile = Profile(
+            name="test",
+            auth=auth,
+            backends={"b": Backend(url="http://x:8000/mcp", compress_descriptions=True)},
+        )
+        set_profiles({"test": profile})
+
+        with patch(
+            "mcp_trentina_crunchtools.gateway.compress.precompress_all",
+            new_callable=AsyncMock,
+            return_value={},
+        ):
+            await maybe_trigger_compression()
+
+        assert compress_mod._compress_task is not None
+        assert compress_mod._compress_triggered is True
+
+
+class TestRetryLogic:
+    """Tests for Gemini API retry on 429/503."""
+
+    def _gemini_response(self, items: list[tuple[str, str]]) -> dict[str, Any]:
+        compressed = [{"id": h, "text": text} for h, text in items]
+        return {
+            "candidates": [{
+                "content": {
+                    "parts": [{"text": json.dumps({"compressed": compressed})}]
+                }
+            }]
+        }
+
+    @pytest.mark.asyncio
+    async def test_retries_on_503(self) -> None:
+        success_resp = MagicMock()
+        success_resp.json.return_value = self._gemini_response([("h1", "Short.")])
+        success_resp.raise_for_status.return_value = None
+
+        error_resp = MagicMock()
+        error_resp.status_code = 503
+        error_503 = httpx.HTTPStatusError("503", request=MagicMock(), response=error_resp)
+
+        with patch("mcp_trentina_crunchtools.gateway.compress.get_config") as mock_config:
+            mock_config.return_value.has_api_key = True
+            mock_config.return_value.api_key.get_secret_value.return_value = "key"
+
+            with patch("mcp_trentina_crunchtools.gateway.compress.httpx") as mock_httpx:
+                mock_client = AsyncMock()
+                mock_client.post.side_effect = [error_503, success_resp]
+
+                mock_httpx.AsyncClient.return_value.__aenter__.return_value = mock_client
+                mock_httpx.Timeout = httpx.Timeout
+                mock_httpx.HTTPStatusError = httpx.HTTPStatusError
+
+                with patch("mcp_trentina_crunchtools.gateway.compress.RETRY_BASE_DELAY", 0.01):
+                    result = await _call_compress_model([("h1", "Long description")])
+
+        assert len(result) == 1
+        assert result[0] == ("h1", "Short.")
+        assert mock_client.post.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_retries_on_429(self) -> None:
+        success_resp = MagicMock()
+        success_resp.json.return_value = self._gemini_response([("h1", "Short.")])
+        success_resp.raise_for_status.return_value = None
+
+        error_resp = MagicMock()
+        error_resp.status_code = 429
+        error_429 = httpx.HTTPStatusError("429", request=MagicMock(), response=error_resp)
+
+        with patch("mcp_trentina_crunchtools.gateway.compress.get_config") as mock_config:
+            mock_config.return_value.has_api_key = True
+            mock_config.return_value.api_key.get_secret_value.return_value = "key"
+
+            with patch("mcp_trentina_crunchtools.gateway.compress.httpx") as mock_httpx:
+                mock_client = AsyncMock()
+                mock_client.post.side_effect = [error_429, success_resp]
+
+                mock_httpx.AsyncClient.return_value.__aenter__.return_value = mock_client
+                mock_httpx.Timeout = httpx.Timeout
+                mock_httpx.HTTPStatusError = httpx.HTTPStatusError
+
+                with patch("mcp_trentina_crunchtools.gateway.compress.RETRY_BASE_DELAY", 0.01):
+                    result = await _call_compress_model([("h1", "Long description")])
+
+        assert len(result) == 1
+        assert mock_client.post.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_gives_up_after_max_retries(self) -> None:
+        error_resp = MagicMock()
+        error_resp.status_code = 503
+        error_503 = httpx.HTTPStatusError("503", request=MagicMock(), response=error_resp)
+
+        with patch("mcp_trentina_crunchtools.gateway.compress.get_config") as mock_config:
+            mock_config.return_value.has_api_key = True
+            mock_config.return_value.api_key.get_secret_value.return_value = "key"
+
+            with patch("mcp_trentina_crunchtools.gateway.compress.httpx") as mock_httpx:
+                mock_client = AsyncMock()
+                mock_client.post.side_effect = error_503
+
+                mock_httpx.AsyncClient.return_value.__aenter__.return_value = mock_client
+                mock_httpx.Timeout = httpx.Timeout
+                mock_httpx.HTTPStatusError = httpx.HTTPStatusError
+
+                with patch("mcp_trentina_crunchtools.gateway.compress.RETRY_BASE_DELAY", 0.01):
+                    result = await _call_compress_model([("h1", "desc")])
+
+        assert result == []
+        assert mock_client.post.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_no_retry_on_400(self) -> None:
+        error_resp = MagicMock()
+        error_resp.status_code = 400
+        error_400 = httpx.HTTPStatusError("400", request=MagicMock(), response=error_resp)
+
+        with patch("mcp_trentina_crunchtools.gateway.compress.get_config") as mock_config:
+            mock_config.return_value.has_api_key = True
+            mock_config.return_value.api_key.get_secret_value.return_value = "key"
+
+            with patch("mcp_trentina_crunchtools.gateway.compress.httpx") as mock_httpx:
+                mock_client = AsyncMock()
+                mock_client.post.side_effect = error_400
+
+                mock_httpx.AsyncClient.return_value.__aenter__.return_value = mock_client
+                mock_httpx.Timeout = httpx.Timeout
+                mock_httpx.HTTPStatusError = httpx.HTTPStatusError
+
+                result = await _call_compress_model([("h1", "desc")])
+
+        assert result == []
+        assert mock_client.post.call_count == 1


### PR DESCRIPTION
## Summary

- Redesigns pre-compression to trigger lazily on the first `tools/list` request instead of at startup
- Uses `asyncio.create_task` on the already-running main event loop — sidesteps all three prior failure modes (FastMCP lifespan, daemon threads, event loop incompatibility)
- First request returns uncompressed descriptions (cache misses = passthrough); subsequent calls get compressed versions from the in-memory cache
- Adds retry with exponential backoff (2s base, 2x multiplier, 3 attempts) for Gemini 429/503 errors
- Removes the disabled pre-compression comment block

Closes #31

## Test plan
- [x] 24 compression tests pass (7 existing + 7 new trigger/retry tests)
- [x] Full test suite: 379 passed, 32 skipped
- [x] ruff, mypy, pytest all green
- [ ] Deploy to lotor, verify `quarantine_stats` shows compression stats after first tools/list call

🤖 Generated with [Claude Code](https://claude.com/claude-code)