### PR TITLE
fix(gateway): circuit breaker + parallel backend fetching

### DIFF
--- a/.specify/specs/008-circuit-breaker/plan.md
+++ b/.specify/specs/008-circuit-breaker/plan.md
@@ -1,0 +1,163 @@
+# Implementation Plan: Backend Circuit Breaker
+
+> **Spec ID:** 008-circuit-breaker
+> **Status:** Planning
+> **Last Updated:** 2026-06-28
+
+## Summary
+
+Three-part fix: (1) parallelize `tools/list` backend fetching with `asyncio.gather`, (2) add a circuit breaker to `backend.py` that tracks failures per-URL and short-circuits known-dead backends, (3) add a separate shorter timeout for tool listing vs operational calls.
+
+---
+
+## Architecture
+
+### Failure Flow (current)
+
+```
+tools/list request
+    │
+    ├── backend-1 (healthy) ── 200ms ──┐
+    ├── backend-2 (dead)    ── 30s  ──┤  sequential
+    ├── backend-3 (healthy) ── 150ms ──┤  total = sum
+    └── ...                            │
+                                       ▼
+                              response (30.35s)
+```
+
+### Failure Flow (after)
+
+```
+tools/list request
+    │
+    ├── backend-1 (healthy) ── 200ms ──┐
+    ├── backend-2 (circuit open) ── 0ms ──┤  parallel
+    ├── backend-3 (healthy) ── 150ms ──┤  total = max
+    └── ...                            │
+                                       ▼
+                              response (200ms)
+```
+
+### Circuit Breaker State Machine
+
+```
+         success
+    ┌──────────────┐
+    │              │
+    ▼              │
+ CLOSED ──N fails──> OPEN ──cooldown──> HALF_OPEN
+    ▲                  ▲                   │
+    │                  │                   │
+    │                  └───── fail ────────┘
+    │                                      │
+    └──────────── success ─────────────────┘
+```
+
+---
+
+## Implementation Steps
+
+### Phase 1: Circuit Breaker Module
+
+- [ ] Create `gateway/circuit.py` with `CircuitBreaker` class
+  - Per-URL state tracking (dict keyed by URL)
+  - Thread-safe via asyncio (single event loop, no locks needed)
+  - `check(url)` — returns True if call allowed, False if circuit open
+  - `record_success(url)` — reset failure count, close circuit
+  - `record_failure(url)` — increment count, open if threshold reached
+  - Uses `time.monotonic()` for cooldown timing (immune to clock skew)
+
+### Phase 2: Backend Integration
+
+- [ ] Add `list_timeout_seconds` field to `Backend` model in `profile.py`
+  - Default: 10.0, gt=0, le=60.0
+- [ ] Modify `list_backend_tools` in `backend.py` to:
+  - Check circuit breaker before attempting connection
+  - Use `list_timeout_seconds` instead of `timeout_seconds`
+  - Record success/failure to circuit breaker
+- [ ] Modify `call_backend_tool` to record success/failure to circuit breaker
+
+### Phase 3: Parallel tools/list
+
+- [ ] Rewrite `_route_tools_list` in `router.py`:
+  - Create async tasks for all backends
+  - Use `asyncio.gather(*tasks, return_exceptions=True)`
+  - Collect results, skip exceptions (same as current `continue` behavior)
+  - Log skipped backends with reason (timeout, circuit open, other error)
+
+### Phase 4: Tests
+
+- [ ] `tests/test_circuit_breaker.py` — state machine unit tests
+- [ ] Update `tests/test_gateway_router.py` — parallel fetch tests
+- [ ] Update `tests/test_gateway_backend.py` if it exists, or add backend-level tests
+
+### Phase 5: Quality Gates
+
+- [ ] `uv run ruff check src tests`
+- [ ] `uv run mypy src`
+- [ ] `uv run pytest -v`
+- [ ] `gourmand --full .` (if available)
+- [ ] `podman build -f Containerfile .`
+
+---
+
+## File Changes
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `gateway/circuit.py` | Circuit breaker state machine |
+| `tests/test_circuit_breaker.py` | Circuit breaker unit tests |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `gateway/profile.py` | Add `list_timeout_seconds` to `Backend` |
+| `gateway/backend.py` | Circuit breaker checks + list timeout |
+| `gateway/router.py` | `asyncio.gather` in `_route_tools_list` |
+| `gateway/__init__.py` | Export circuit breaker module |
+
+---
+
+## Testing Strategy
+
+### Unit Tests (circuit.py)
+
+- State transitions: closed → open → half-open → closed
+- Failure threshold boundary (2 failures = still closed, 3 = open)
+- Cooldown expiry (mock time.monotonic)
+- Half-open probe semantics (one allowed, rest rejected)
+- Independent circuits per URL
+
+### Integration Tests (router.py)
+
+- Parallel fetch returns tools from all healthy backends
+- Dead backend skipped, healthy backends unaffected
+- Circuit-open backend returns immediately (no wait)
+- Mixed internal + external backends with one dead
+
+### Regression Tests
+
+- Existing `test_tools_list_skips_unreachable_backend` still passes
+- Existing `test_tools_list_aggregates_and_namespaces` still passes
+
+---
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Circuit stays open after backend recovers | Med | 60s cooldown + half-open probe ensures recovery within ~1 min |
+| `asyncio.gather` changes tool ordering | Low | Tool order was never guaranteed; clients don't depend on it |
+| Race condition in circuit state | Low | Single event loop, no threads; `time.monotonic` is monotonic |
+| Backend flaps (up-down-up rapidly) | Low | 3-failure threshold prevents premature opens; success resets immediately |
+
+---
+
+## Changelog
+
+| Date | Changes |
+|------|---------|
+| 2026-06-28 | Initial plan |

--- a/.specify/specs/008-circuit-breaker/spec.md
+++ b/.specify/specs/008-circuit-breaker/spec.md
@@ -1,0 +1,183 @@
+# Specification: Backend Circuit Breaker
+
+> **Spec ID:** 008-circuit-breaker
+> **Status:** Draft
+> **Version:** 0.1.0
+> **Author:** Scott McCarty
+> **Date:** 2026-06-28
+
+## Overview
+
+Trentina is critical infrastructure — every Claude Code session, every agent (Kagetora, Takeda), and every LLM proxy request flows through it. A single unreachable backend MCP server currently blocks the entire `tools/list` response, taking down all profiles that reference that backend. This spec adds a circuit breaker to the gateway backend layer so that backend failures are isolated, fast, and self-healing.
+
+---
+
+## Problem Analysis
+
+### Root Cause
+
+`_route_tools_list` in `router.py` iterates backends **sequentially** with a `for` loop. Each backend call wraps `_do_list_tools` in `asyncio.wait_for(timeout=backend.timeout_seconds)`. The default timeout is **30 seconds**. A profile with 12 backends and 1 dead backend blocks `tools/list` for up to 30 seconds before skipping the dead one and proceeding — which exceeds Claude Code's MCP connection timeout.
+
+### Failure Cascade
+
+```
+Dead backend (e.g. rotv, 30s timeout)
+    → tools/list blocks for 30s
+    → Claude Code MCP connection times out (~20s)
+    → Client reconnects, hits tools/list again
+    → Same 30s block, same timeout
+    → Gateway appears completely dead
+```
+
+### All Failure Surfaces (audit)
+
+| Surface | Current Behavior | Risk |
+|---------|-----------------|------|
+| `tools/list` — sequential backend iteration | 30s timeout per dead backend, blocks entire response | **Critical** — the #36 bug |
+| `tools/list` — `maybe_trigger_compression()` | Calls `list_backend_tools` for each compressible backend; same sequential + 30s timeout | **High** — compression of a dead backend blocks startup |
+| `tools/call` — single backend call | 30s timeout, returns JSON-RPC error | **Medium** — affects only one call, client retries |
+| LLM proxy — upstream timeout | 300s read timeout (appropriate for streaming LLM), returns 504 | **Low** — per-request, no cascade |
+| Matrix proxy — upstream timeout | 120s read timeout (appropriate for /sync long-poll), returns 504 | **Low** — per-request, no cascade |
+| Compression — Gemini timeout | 60s timeout with retries, logged and skipped | **Low** — best-effort by design |
+
+---
+
+## Solution: Three-Part Fix
+
+### Part 1: Parallel Backend Fetching in tools/list
+
+Replace the sequential `for` loop in `_route_tools_list` with `asyncio.gather` so all backends are queried concurrently. A dead backend's timeout no longer blocks healthy backends.
+
+**Before:** Wall-clock = sum of all backend timeouts
+**After:** Wall-clock = max of all backend timeouts (in practice, the healthy ones return in <1s)
+
+### Part 2: Circuit Breaker on Backend Connections
+
+Add a circuit breaker to `backend.py` that tracks consecutive failures per backend URL. After N consecutive failures (default: 3), the circuit opens and immediately rejects calls for a cooldown period (default: 60 seconds) without attempting the connection.
+
+States:
+- **Closed** (normal): calls pass through to the backend
+- **Open** (tripped): calls fail immediately with `BackendCallError("circuit open")`
+- **Half-open** (probing): after cooldown expires, one call is allowed through to test recovery
+
+This prevents the gateway from spending timeout-seconds on every single request to a known-dead backend.
+
+### Part 3: Short Timeout for tools/list
+
+Add a separate, shorter timeout for `list_backend_tools` (default: 10 seconds) distinct from `call_backend_tool`'s operational timeout (remains at `backend.timeout_seconds`, default 30s). Tool listing is a lightweight metadata operation — if a backend can't respond in 10 seconds, it's effectively down.
+
+---
+
+## No New Tools
+
+This change is internal to the gateway. No new MCP tools are added.
+
+---
+
+## Security Considerations
+
+### Layer 1 — Token Protection
+- No change. Circuit breaker state is in-memory, not persisted.
+
+### Layer 2 — Input Validation
+- No change. Circuit breaker parameters use existing Pydantic validation on `Backend` model.
+
+### Layer 3 — API Hardening
+- **Improved.** Shorter list timeout and circuit breaker reduce the window for connection-level DoS against the gateway.
+
+### Layer 4 — Dangerous Operation Prevention
+- No change. No new filesystem or shell access.
+
+### Security Note
+- Circuit breaker state is **not** controllable by consumers. A consumer cannot force a circuit open or closed — state transitions are driven entirely by backend response behavior observed by the gateway.
+
+---
+
+## Module Changes
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `gateway/circuit.py` | Circuit breaker implementation |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `gateway/backend.py` | Integrate circuit breaker checks before backend calls |
+| `gateway/router.py` | Replace sequential loop with `asyncio.gather` in `_route_tools_list` |
+| `gateway/profile.py` | Add `list_timeout_seconds` field to `Backend` model |
+| `gateway/__init__.py` | Export circuit breaker if needed for stats |
+
+---
+
+## Testing Requirements
+
+### Mocked Tests
+
+- [ ] `test_circuit_breaker.py` — unit tests for circuit state machine
+  - Closed → stays closed on success
+  - Closed → opens after N consecutive failures
+  - Open → rejects immediately (no backend call)
+  - Open → transitions to half-open after cooldown
+  - Half-open → closes on success
+  - Half-open → re-opens on failure
+  - Concurrent calls during half-open: only one probe allowed
+- [ ] `test_gateway_router.py` — new tests
+  - tools/list with parallel fetch (multiple backends, verify all returned)
+  - tools/list with one dead backend (verify others still returned promptly)
+  - tools/list with circuit-open backend (verify immediate skip, no timeout)
+- [ ] `test_gateway_backend.py` — new tests
+  - list_backend_tools respects `list_timeout_seconds`
+  - Circuit breaker integration (failure count tracking)
+
+### Input Validation Tests
+- [ ] `list_timeout_seconds` Pydantic validation (positive, <= 60s)
+
+### Tool Count Update
+- [ ] No change — no new tools
+
+---
+
+## Configuration
+
+### Backend Model Additions
+
+```yaml
+backends:
+  rotv:
+    url: http://mcp-rotv:8080/mcp
+    timeout_seconds: 30        # operational call timeout (existing)
+    list_timeout_seconds: 10   # tools/list timeout (new, default 10)
+```
+
+### Circuit Breaker Defaults (not configurable per-backend in v1)
+
+| Parameter | Default | Rationale |
+|-----------|---------|-----------|
+| `failure_threshold` | 3 | Open after 3 consecutive failures |
+| `cooldown_seconds` | 60 | Wait 60s before probing |
+| `half_open_max_probes` | 1 | Only 1 concurrent probe in half-open |
+
+---
+
+## Dependencies
+
+- Depends on: None
+- Blocks: None
+
+---
+
+## Open Questions
+
+1. Should circuit breaker state be observable via `quarantine_stats` or a new gateway health endpoint? (Defer to #14, Cockpit rewrite.)
+2. Should circuit breaker parameters be configurable per-backend in YAML? (Not in v1 — keep it simple, add if needed.)
+
+---
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 0.1.0 | 2026-06-28 | Initial draft |

--- a/src/mcp_trentina_crunchtools/gateway/__init__.py
+++ b/src/mcp_trentina_crunchtools/gateway/__init__.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from .app import gateway_app, register_with_fastmcp
 from .auth import verify_bearer
 from .backend import BackendCall, call_backend_tool, list_backend_tools
+from .circuit import CircuitBreaker, breaker
 from .errors import AuthError, GatewayError, ProfileConfigError
 from .filter import filter_tools
 from .guards import check_parameter_guards
@@ -32,11 +33,13 @@ __all__ = [
     "AuthError",
     "Backend",
     "BackendCall",
+    "CircuitBreaker",
     "DefenseConfig",
     "ParameterConstraint",
     "GatewayError",
     "Profile",
     "ProfileConfigError",
+    "breaker",
     "check_parameter_guards",
     "call_backend_tool",
     "call_internal_tool",

--- a/src/mcp_trentina_crunchtools/gateway/backend.py
+++ b/src/mcp_trentina_crunchtools/gateway/backend.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any
 from mcp import ClientSession
 from mcp.client.streamable_http import streamablehttp_client
 
+from .circuit import breaker
 from .errors import BackendCallError
 
 if TYPE_CHECKING:
@@ -43,15 +44,22 @@ async def list_backend_tools(backend_name: str, backend: Backend) -> list[dict[s
     caller does the `<backend>__<tool>` rewrite.
 
     Raises:
-        BackendCallError: connection failure, protocol error, or timeout.
+        BackendCallError: connection failure, protocol error, timeout, or
+            circuit open.
     """
+    if not breaker.allow(backend.url):
+        raise BackendCallError(
+            f"backend {backend_name!r} circuit open — skipped"
+        )
+
     headers = backend.headers or None
     try:
         tools_result = await asyncio.wait_for(
             _do_list_tools(backend.url, headers),
-            timeout=backend.timeout_seconds,
+            timeout=backend.list_timeout_seconds,
         )
     except Exception as exc:
+        breaker.record_failure(backend.url)
         logger.warning(
             "gateway: list_tools failed for backend=%s url=%s err=%s",
             backend_name,
@@ -62,6 +70,7 @@ async def list_backend_tools(backend_name: str, backend: Backend) -> list[dict[s
             f"backend {backend_name!r} list_tools failed: {type(exc).__name__}"
         ) from exc
 
+    breaker.record_success(backend.url)
     return [_serialize_tool(tool) for tool in tools_result.tools]
 
 
@@ -77,8 +86,14 @@ async def call_backend_tool(
     L1/L2/L3 defense pipeline before returning.
 
     Raises:
-        BackendCallError: connection failure, protocol error, or timeout.
+        BackendCallError: connection failure, protocol error, timeout, or
+            circuit open.
     """
+    if not breaker.allow(backend.url):
+        raise BackendCallError(
+            f"backend {backend_name!r} circuit open — skipped"
+        )
+
     headers = backend.headers or None
     try:
         result = await asyncio.wait_for(
@@ -86,6 +101,7 @@ async def call_backend_tool(
             timeout=backend.timeout_seconds,
         )
     except Exception as exc:
+        breaker.record_failure(backend.url)
         logger.warning(
             "gateway: call_tool failed backend=%s tool=%s err=%s",
             backend_name,
@@ -96,6 +112,7 @@ async def call_backend_tool(
             f"backend {backend_name!r} call_tool failed: {type(exc).__name__}"
         ) from exc
 
+    breaker.record_success(backend.url)
     content: list[dict[str, Any]] = [_serialize_content_block(b) for b in result.content]
     structured = getattr(result, "structuredContent", None)
     return BackendCall(

--- a/src/mcp_trentina_crunchtools/gateway/circuit.py
+++ b/src/mcp_trentina_crunchtools/gateway/circuit.py
@@ -1,0 +1,136 @@
+"""Per-URL circuit breaker for backend MCP connections.
+
+Tracks consecutive failures per backend URL. After ``failure_threshold``
+consecutive failures the circuit opens and immediately rejects calls for
+``cooldown_seconds``.  After cooldown, one probe call is allowed through
+(half-open); success closes the circuit, failure re-opens it.
+
+All state is in-memory (single event loop, no locking needed).  Timing
+uses ``time.monotonic`` so clock adjustments cannot extend a cooldown.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from enum import Enum
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_FAILURE_THRESHOLD = 3
+DEFAULT_COOLDOWN_SECONDS = 60.0
+
+
+class State(Enum):
+    CLOSED = "closed"
+    OPEN = "open"
+    HALF_OPEN = "half_open"
+
+
+class _CircuitState:
+    """Mutable state for one circuit (one backend URL)."""
+
+    __slots__ = (
+        "consecutive_failures",
+        "opened_at",
+        "probe_in_flight",
+        "state",
+    )
+
+    def __init__(self) -> None:
+        self.state = State.CLOSED
+        self.consecutive_failures = 0
+        self.opened_at = 0.0
+        self.probe_in_flight = False
+
+
+class CircuitBreaker:
+    """Circuit breaker registry keyed by backend URL."""
+
+    def __init__(
+        self,
+        failure_threshold: int = DEFAULT_FAILURE_THRESHOLD,
+        cooldown_seconds: float = DEFAULT_COOLDOWN_SECONDS,
+    ) -> None:
+        self._threshold = failure_threshold
+        self._cooldown = cooldown_seconds
+        self._circuits: dict[str, _CircuitState] = {}
+
+    def _get(self, url: str) -> _CircuitState:
+        circuit = self._circuits.get(url)
+        if circuit is None:
+            circuit = _CircuitState()
+            self._circuits[url] = circuit
+        return circuit
+
+    def allow(self, url: str) -> bool:
+        """Return True if a call to *url* should proceed.
+
+        - Closed: always allowed.
+        - Open: blocked until cooldown expires, then one probe is allowed
+          (transition to half-open).
+        - Half-open: blocked if a probe is already in flight.
+        """
+        circuit = self._get(url)
+
+        if circuit.state is State.CLOSED:
+            return True
+
+        if circuit.state is State.OPEN:
+            elapsed = time.monotonic() - circuit.opened_at
+            if elapsed < self._cooldown:
+                return False
+            circuit.state = State.HALF_OPEN
+            circuit.probe_in_flight = True
+            logger.info("circuit: %s half-open, allowing probe", url)
+            return True
+
+        if circuit.probe_in_flight:
+            return False
+        circuit.probe_in_flight = True
+        return True
+
+    def record_success(self, url: str) -> None:
+        """Record a successful call — reset failures and close the circuit."""
+        circuit = self._get(url)
+        was_open = circuit.state is not State.CLOSED
+        circuit.consecutive_failures = 0
+        circuit.probe_in_flight = False
+        circuit.state = State.CLOSED
+        if was_open:
+            logger.info("circuit: %s closed after successful probe", url)
+
+    def record_failure(self, url: str) -> None:
+        """Record a failed call — increment counter, open if threshold reached."""
+        circuit = self._get(url)
+        circuit.consecutive_failures += 1
+        circuit.probe_in_flight = False
+
+        if circuit.state is State.HALF_OPEN:
+            circuit.state = State.OPEN
+            circuit.opened_at = time.monotonic()
+            logger.warning("circuit: %s re-opened after failed probe", url)
+            return
+
+        if circuit.consecutive_failures >= self._threshold:
+            circuit.state = State.OPEN
+            circuit.opened_at = time.monotonic()
+            logger.warning(
+                "circuit: %s opened after %d consecutive failures",
+                url,
+                circuit.consecutive_failures,
+            )
+
+    def get_state(self, url: str) -> State:
+        """Return the current state for *url* (for diagnostics/logging)."""
+        return self._get(url).state
+
+    def reset(self, url: str | None = None) -> None:
+        """Reset one circuit or all circuits (for testing)."""
+        if url is None:
+            self._circuits.clear()
+        else:
+            self._circuits.pop(url, None)
+
+
+breaker = CircuitBreaker()

--- a/src/mcp_trentina_crunchtools/gateway/profile.py
+++ b/src/mcp_trentina_crunchtools/gateway/profile.py
@@ -24,6 +24,7 @@ ENV_NAME_RE = re.compile(r"^[A-Z_][A-Z0-9_]*$")
 INTERNAL_SCHEME = "internal://"
 
 MAX_BACKEND_TIMEOUT_SECONDS = 300.0
+MAX_LIST_TIMEOUT_SECONDS = 60.0
 
 
 class AuthConfig(BaseModel):
@@ -109,6 +110,12 @@ class Backend(BaseModel):
         gt=0,
         le=MAX_BACKEND_TIMEOUT_SECONDS,
         description="Per-call backend timeout",
+    )
+    list_timeout_seconds: float = Field(
+        default=10.0,
+        gt=0,
+        le=MAX_LIST_TIMEOUT_SECONDS,
+        description="Timeout for tools/list metadata fetch (shorter than operational calls)",
     )
     parameter_guards: dict[str, dict[str, ParameterConstraint]] = Field(
         default_factory=dict,

--- a/src/mcp_trentina_crunchtools/gateway/router.py
+++ b/src/mcp_trentina_crunchtools/gateway/router.py
@@ -17,6 +17,7 @@ inserts the L1/L2/L3 defense pipeline here.
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import logging
 import time
@@ -32,7 +33,7 @@ from .guards import check_parameter_guards
 from .internal import call_internal_tool, list_internal_tools
 
 if TYPE_CHECKING:
-    from .profile import Profile
+    from .profile import Backend, Profile
 
 logger = logging.getLogger(__name__)
 
@@ -123,33 +124,49 @@ async def route_jsonrpc(profile: Profile, request: dict[str, Any]) -> dict[str, 
 async def _route_tools_list(profile: Profile, req_id: Any) -> dict[str, Any]:
     """Aggregate tools/list across the profile's backends, filtered and namespaced.
 
-    A failing backend (down, timing out, refusing) is logged and skipped so
-    the rest of the fleet stays usable. The consumer still sees the union
-    of healthy backends.
+    All backends are queried in parallel via asyncio.gather.  A failing
+    backend (down, circuit open, timing out) is logged and skipped so the
+    rest of the fleet stays usable.  Wall-clock time is the slowest
+    healthy backend, not the sum of all timeouts.
     """
     await maybe_trigger_compression()
+
+    async def _fetch_one(
+        backend_name: str, backend: Backend,
+    ) -> list[dict[str, Any]]:
+        if backend.is_internal:
+            raw_tools = await list_internal_tools()
+        else:
+            raw_tools = await list_backend_tools(backend_name, backend)
+        filtered = filter_tools(raw_tools, backend)
+        if backend.compress_descriptions:
+            filtered = compress_tools(filtered)
+        namespaced: list[dict[str, Any]] = []
+        for tool in filtered:
+            namespaced_tool = dict(tool)
+            namespaced_tool["name"] = f"{backend_name}{NAMESPACE_SEP}{tool['name']}"
+            namespaced.append(namespaced_tool)
+        return namespaced
+
+    tasks = [
+        _fetch_one(name, backend)
+        for name, backend in profile.backends.items()
+    ]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
     aggregated: list[dict[str, Any]] = []
-    for backend_name, backend in profile.backends.items():
-        try:
-            if backend.is_internal:
-                backend_tools = await list_internal_tools()
-            else:
-                backend_tools = await list_backend_tools(backend_name, backend)
-        except BackendCallError as exc:
+    for (backend_name, _backend), outcome in zip(
+        profile.backends.items(), results, strict=True,
+    ):
+        if isinstance(outcome, BaseException):
             logger.warning(
                 "gateway: tools/list profile=%s backend=%s skipped: %s",
                 profile.name,
                 backend_name,
-                exc,
+                outcome,
             )
             continue
-        filtered = filter_tools(backend_tools, backend)
-        if backend.compress_descriptions:
-            filtered = compress_tools(filtered)
-        for tool in filtered:
-            namespaced_tool = dict(tool)
-            namespaced_tool["name"] = f"{backend_name}{NAMESPACE_SEP}{tool['name']}"
-            aggregated.append(namespaced_tool)
+        aggregated.extend(outcome)
 
     return _ok(req_id, {"tools": aggregated})
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+"""Shared fixtures for gateway tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_trentina_crunchtools.gateway.circuit import breaker
+
+
+@pytest.fixture(autouse=True)
+def _reset_circuit_breaker() -> None:
+    """Reset the global circuit breaker before every test.
+
+    The module-level ``breaker`` singleton accumulates state across tests.
+    Without this fixture, a test that opens a circuit and then fails before
+    calling ``breaker.reset()`` leaks that state into subsequent tests.
+    """
+    breaker.reset()

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -1,0 +1,140 @@
+"""Tests for gateway/circuit.py — circuit breaker state machine."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from mcp_trentina_crunchtools.gateway.circuit import (
+    CircuitBreaker,
+    State,
+)
+
+URL = "http://mcp-rotv:8080/mcp"
+URL_B = "http://mcp-slack:8005/mcp"
+
+
+class TestCircuitBreaker:
+    """State machine transitions: closed → open → half-open → closed."""
+
+    def _breaker(self, threshold: int = 3, cooldown: float = 60.0) -> CircuitBreaker:
+        return CircuitBreaker(failure_threshold=threshold, cooldown_seconds=cooldown)
+
+    def test_initial_state_is_closed(self) -> None:
+        cb = self._breaker()
+        assert cb.get_state(URL) is State.CLOSED
+        assert cb.allow(URL) is True
+
+    def test_success_keeps_closed(self) -> None:
+        cb = self._breaker()
+        cb.record_success(URL)
+        assert cb.get_state(URL) is State.CLOSED
+        assert cb.allow(URL) is True
+
+    def test_failures_below_threshold_stay_closed(self) -> None:
+        cb = self._breaker(threshold=3)
+        cb.record_failure(URL)
+        cb.record_failure(URL)
+        assert cb.get_state(URL) is State.CLOSED
+        assert cb.allow(URL) is True
+
+    def test_failures_at_threshold_open_circuit(self) -> None:
+        cb = self._breaker(threshold=3)
+        cb.record_failure(URL)
+        cb.record_failure(URL)
+        cb.record_failure(URL)
+        assert cb.get_state(URL) is State.OPEN
+        assert cb.allow(URL) is False
+
+    def test_open_circuit_blocks_calls(self) -> None:
+        cb = self._breaker(threshold=1)
+        cb.record_failure(URL)
+        assert cb.allow(URL) is False
+        assert cb.allow(URL) is False
+
+    def test_success_resets_failure_count(self) -> None:
+        cb = self._breaker(threshold=3)
+        cb.record_failure(URL)
+        cb.record_failure(URL)
+        cb.record_success(URL)
+        cb.record_failure(URL)
+        cb.record_failure(URL)
+        assert cb.get_state(URL) is State.CLOSED
+
+    def test_cooldown_transitions_to_half_open(self) -> None:
+        cb = self._breaker(threshold=1, cooldown=10.0)
+        cb.record_failure(URL)
+        assert cb.get_state(URL) is State.OPEN
+
+        with patch("mcp_trentina_crunchtools.gateway.circuit.time") as mock_time:
+            mock_time.monotonic.side_effect = [100.0, 200.0]
+            cb._get(URL).opened_at = 90.0
+            assert cb.allow(URL) is True
+            assert cb.get_state(URL) is State.HALF_OPEN
+
+    def test_cooldown_not_expired_stays_open(self) -> None:
+        cb = self._breaker(threshold=1, cooldown=60.0)
+        cb.record_failure(URL)
+
+        with patch("mcp_trentina_crunchtools.gateway.circuit.time") as mock_time:
+            mock_time.monotonic.return_value = 30.0
+            cb._get(URL).opened_at = 0.0
+            assert cb.allow(URL) is False
+            assert cb.get_state(URL) is State.OPEN
+
+    def test_half_open_success_closes_circuit(self) -> None:
+        cb = self._breaker(threshold=1, cooldown=0.0)
+        cb.record_failure(URL)
+
+        with patch("mcp_trentina_crunchtools.gateway.circuit.time") as mock_time:
+            mock_time.monotonic.return_value = 100.0
+            cb._get(URL).opened_at = 0.0
+            assert cb.allow(URL) is True
+
+        cb.record_success(URL)
+        assert cb.get_state(URL) is State.CLOSED
+        assert cb.allow(URL) is True
+
+    def test_half_open_failure_reopens_circuit(self) -> None:
+        cb = self._breaker(threshold=1, cooldown=0.0)
+        cb.record_failure(URL)
+
+        with patch("mcp_trentina_crunchtools.gateway.circuit.time") as mock_time:
+            mock_time.monotonic.side_effect = [100.0, 200.0]
+            cb._get(URL).opened_at = 0.0
+            assert cb.allow(URL) is True
+
+        cb.record_failure(URL)
+        assert cb.get_state(URL) is State.OPEN
+
+    def test_half_open_blocks_second_probe(self) -> None:
+        cb = self._breaker(threshold=1, cooldown=0.0)
+        cb.record_failure(URL)
+
+        with patch("mcp_trentina_crunchtools.gateway.circuit.time") as mock_time:
+            mock_time.monotonic.return_value = 100.0
+            cb._get(URL).opened_at = 0.0
+            assert cb.allow(URL) is True
+            assert cb.allow(URL) is False
+
+    def test_independent_circuits_per_url(self) -> None:
+        cb = self._breaker(threshold=1)
+        cb.record_failure(URL)
+        assert cb.get_state(URL) is State.OPEN
+        assert cb.get_state(URL_B) is State.CLOSED
+        assert cb.allow(URL_B) is True
+
+    def test_reset_single_url(self) -> None:
+        cb = self._breaker(threshold=1)
+        cb.record_failure(URL)
+        cb.record_failure(URL_B)
+        cb.reset(URL)
+        assert cb.get_state(URL) is State.CLOSED
+        assert cb.get_state(URL_B) is State.OPEN
+
+    def test_reset_all(self) -> None:
+        cb = self._breaker(threshold=1)
+        cb.record_failure(URL)
+        cb.record_failure(URL_B)
+        cb.reset()
+        assert cb.get_state(URL) is State.CLOSED
+        assert cb.get_state(URL_B) is State.CLOSED

--- a/tests/test_gateway_backend.py
+++ b/tests/test_gateway_backend.py
@@ -1,0 +1,238 @@
+"""Tests for gateway/backend.py — circuit breaker integration and timeout wiring.
+
+Patches at the transport layer (_do_list_tools, _do_call_tool) so the real
+list_backend_tools / call_backend_tool run their circuit breaker checks,
+timeout wrapping, and success/failure recording.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from mcp_trentina_crunchtools.gateway.backend import (
+    call_backend_tool,
+    list_backend_tools,
+)
+from mcp_trentina_crunchtools.gateway.circuit import State, breaker
+from mcp_trentina_crunchtools.gateway.errors import BackendCallError
+from mcp_trentina_crunchtools.gateway.profile import Backend
+
+
+def _backend(
+    url: str = "http://mcp-rotv:8080/mcp",
+    timeout: float = 30.0,
+    list_timeout: float = 10.0,
+) -> Backend:
+    return Backend(url=url, timeout_seconds=timeout, list_timeout_seconds=list_timeout)
+
+
+class _FakeTool:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.description = ""
+        self.inputSchema: dict[str, Any] = {}
+
+
+class _FakeToolsResult:
+    def __init__(self, names: list[str] | None = None) -> None:
+        self.tools = [_FakeTool(n) for n in (names or ["some_tool"])]
+
+
+class _FakeCallResult:
+    def __init__(self) -> None:
+        self.content = [_FakeTextBlock()]
+        self.isError = False
+        self.structuredContent = None
+
+
+class _FakeTextBlock:
+    type = "text"
+    text = "ok"
+
+
+URL = "http://mcp-rotv:8080/mcp"
+
+
+@pytest.mark.asyncio
+class TestListBackendToolsCircuit:
+    """list_backend_tools circuit breaker integration."""
+
+    async def test_circuit_open_raises_without_transport(self) -> None:
+        """Circuit-open backend raises BackendCallError before touching transport."""
+        for _ in range(3):
+            breaker.record_failure(URL)
+
+        async def should_not_be_called(_url: str, _headers: Any) -> Any:
+            raise AssertionError("transport called despite open circuit")
+
+        with (
+            patch(
+                "mcp_trentina_crunchtools.gateway.backend._do_list_tools",
+                side_effect=should_not_be_called,
+            ),
+            pytest.raises(BackendCallError, match="circuit open"),
+        ):
+            await list_backend_tools("rotv", _backend())
+
+    async def test_success_records_to_circuit(self) -> None:
+        """Successful list_backend_tools closes/keeps-closed the circuit."""
+        breaker.record_failure(URL)
+        breaker.record_failure(URL)
+        assert breaker.get_state(URL) is State.CLOSED
+
+        async def ok_transport(_url: str, _headers: Any) -> _FakeToolsResult:
+            return _FakeToolsResult()
+
+        with patch(
+            "mcp_trentina_crunchtools.gateway.backend._do_list_tools",
+            side_effect=ok_transport,
+        ):
+            tools = await list_backend_tools("rotv", _backend())
+
+        assert len(tools) == 1
+        assert breaker.get_state(URL) is State.CLOSED
+        assert breaker._get(URL).consecutive_failures == 0
+
+    async def test_failure_records_to_circuit(self) -> None:
+        """Transport failure increments the circuit failure counter."""
+
+        async def fail_transport(_url: str, _headers: Any) -> Any:
+            raise ConnectionRefusedError("connection refused")
+
+        with (
+            patch(
+                "mcp_trentina_crunchtools.gateway.backend._do_list_tools",
+                side_effect=fail_transport,
+            ),
+            pytest.raises(BackendCallError),
+        ):
+            await list_backend_tools("rotv", _backend())
+
+        assert breaker._get(URL).consecutive_failures == 1
+
+    async def test_three_failures_open_circuit(self) -> None:
+        """Three consecutive transport failures open the circuit."""
+
+        async def fail_transport(_url: str, _headers: Any) -> Any:
+            raise TimeoutError("timed out")
+
+        with patch(
+            "mcp_trentina_crunchtools.gateway.backend._do_list_tools",
+            side_effect=fail_transport,
+        ):
+            for _ in range(3):
+                with pytest.raises(BackendCallError):
+                    await list_backend_tools("rotv", _backend())
+
+        assert breaker.get_state(URL) is State.OPEN
+
+    async def test_uses_list_timeout_not_call_timeout(self) -> None:
+        """list_backend_tools uses list_timeout_seconds, not timeout_seconds."""
+        captured_timeout: list[float] = []
+
+        original_wait_for = __import__("asyncio").wait_for
+
+        async def spy_wait_for(coro: Any, *, timeout: float) -> Any:
+            captured_timeout.append(timeout)
+            return await original_wait_for(coro, timeout=timeout)
+
+        async def ok_transport(_url: str, _headers: Any) -> _FakeToolsResult:
+            return _FakeToolsResult()
+
+        backend = _backend(timeout=30.0, list_timeout=7.5)
+        with (
+            patch(
+                "mcp_trentina_crunchtools.gateway.backend._do_list_tools",
+                side_effect=ok_transport,
+            ),
+            patch(
+                "mcp_trentina_crunchtools.gateway.backend.asyncio.wait_for",
+                side_effect=spy_wait_for,
+            ),
+        ):
+            await list_backend_tools("rotv", backend)
+
+        assert captured_timeout == [7.5]
+
+
+@pytest.mark.asyncio
+class TestCallBackendToolCircuit:
+    """call_backend_tool circuit breaker integration."""
+
+    async def test_circuit_open_raises_without_transport(self) -> None:
+        for _ in range(3):
+            breaker.record_failure(URL)
+
+        async def should_not_be_called(*_args: Any, **_kwargs: Any) -> Any:
+            raise AssertionError("transport called despite open circuit")
+
+        with (
+            patch(
+                "mcp_trentina_crunchtools.gateway.backend._do_call_tool",
+                side_effect=should_not_be_called,
+            ),
+            pytest.raises(BackendCallError, match="circuit open"),
+        ):
+            await call_backend_tool("rotv", _backend(), "some_tool", {})
+
+    async def test_success_records_to_circuit(self) -> None:
+        breaker.record_failure(URL)
+        breaker.record_failure(URL)
+
+        async def ok_transport(*_args: Any, **_kwargs: Any) -> _FakeCallResult:
+            return _FakeCallResult()
+
+        with patch(
+            "mcp_trentina_crunchtools.gateway.backend._do_call_tool",
+            side_effect=ok_transport,
+        ):
+            result = await call_backend_tool("rotv", _backend(), "some_tool", {})
+
+        assert result.is_error is False
+        assert breaker._get(URL).consecutive_failures == 0
+
+    async def test_failure_records_to_circuit(self) -> None:
+        async def fail_transport(*_args: Any, **_kwargs: Any) -> Any:
+            raise ConnectionRefusedError("refused")
+
+        with (
+            patch(
+                "mcp_trentina_crunchtools.gateway.backend._do_call_tool",
+                side_effect=fail_transport,
+            ),
+            pytest.raises(BackendCallError),
+        ):
+            await call_backend_tool("rotv", _backend(), "some_tool", {})
+
+        assert breaker._get(URL).consecutive_failures == 1
+
+    async def test_uses_call_timeout_not_list_timeout(self) -> None:
+        """call_backend_tool uses timeout_seconds, not list_timeout_seconds."""
+        captured_timeout: list[float] = []
+
+        original_wait_for = __import__("asyncio").wait_for
+
+        async def spy_wait_for(coro: Any, *, timeout: float) -> Any:
+            captured_timeout.append(timeout)
+            return await original_wait_for(coro, timeout=timeout)
+
+        async def ok_transport(*_args: Any, **_kwargs: Any) -> _FakeCallResult:
+            return _FakeCallResult()
+
+        backend = _backend(timeout=30.0, list_timeout=7.5)
+        with (
+            patch(
+                "mcp_trentina_crunchtools.gateway.backend._do_call_tool",
+                side_effect=ok_transport,
+            ),
+            patch(
+                "mcp_trentina_crunchtools.gateway.backend.asyncio.wait_for",
+                side_effect=spy_wait_for,
+            ),
+        ):
+            await call_backend_tool("rotv", backend, "some_tool", {})
+
+        assert captured_timeout == [30.0]

--- a/tests/test_gateway_profile.py
+++ b/tests/test_gateway_profile.py
@@ -136,6 +136,21 @@ class TestProfileModel:
         c = ParameterConstraint(allow=["*@redhat.com", "scott.mccarty@gmail.com", "*"])
         assert len(c.allow) == 3
 
+    def test_list_timeout_defaults(self) -> None:
+        b = Backend(url="http://x/mcp")
+        assert b.list_timeout_seconds == 10.0
+        assert b.timeout_seconds == 30.0
+
+    def test_list_timeout_custom(self) -> None:
+        b = Backend(url="http://x/mcp", list_timeout_seconds=5.0)
+        assert b.list_timeout_seconds == 5.0
+
+    def test_list_timeout_out_of_range(self) -> None:
+        with pytest.raises(ValidationError):
+            Backend(url="http://x/mcp", list_timeout_seconds=0)
+        with pytest.raises(ValidationError):
+            Backend(url="http://x/mcp", list_timeout_seconds=61.0)
+
     def test_defense_defaults(self) -> None:
         d = DefenseConfig()
         assert d.sanitize is True

--- a/tests/test_gateway_router.py
+++ b/tests/test_gateway_router.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import time
 from typing import Any
 from unittest.mock import patch
 
@@ -448,61 +450,79 @@ class TestRouter:
         assert called["tool"] == "send_gmail_message"
         assert resp["result"]["content"] == [{"type": "text", "text": "sent"}]
 
-    async def test_tools_list_parallel_all_healthy(self) -> None:
-        """Parallel fetch returns tools from all healthy backends."""
-        call_order: list[str] = []
+    async def test_tools_list_fetches_concurrently(self) -> None:
+        """Prove backends are fetched in parallel, not sequentially.
 
-        async def fake_list(backend_name: str, _backend: Backend) -> list[dict[str, Any]]:
-            call_order.append(backend_name)
+        Each mock sleeps 0.15s.  With 2 backends, sequential = ~0.30s,
+        parallel < 0.25s.  Assertion uses 0.25s as the threshold.
+        """
+        delay = 0.15
+
+        async def slow_list(backend_name: str, _backend: Backend) -> list[dict[str, Any]]:
+            await asyncio.sleep(delay)
             return [{"name": f"{backend_name}_tool", "description": "", "inputSchema": {}}]
 
         with patch(
             "mcp_trentina_crunchtools.gateway.router.list_backend_tools",
-            side_effect=fake_list,
+            side_effect=slow_list,
         ):
+            t0 = time.monotonic()
             resp = await route_jsonrpc(
                 _profile(), {"jsonrpc": "2.0", "id": 40, "method": "tools/list"}
             )
+            elapsed = time.monotonic() - t0
 
         names = sorted(str(t["name"]) for t in resp["result"]["tools"])
         assert f"mcp-atlassian{NAMESPACE_SEP}mcp-atlassian_tool" in names
         assert f"mcp-slack{NAMESPACE_SEP}mcp-slack_tool" in names
-        assert len(call_order) == 2
+        assert elapsed < delay * 2, (
+            f"Expected parallel execution (<{delay * 2:.2f}s), "
+            f"got {elapsed:.2f}s — backends may be running sequentially"
+        )
 
     async def test_tools_list_circuit_open_skips_immediately(self) -> None:
-        """A backend with an open circuit is skipped without blocking."""
+        """Circuit-open backend is skipped via real list_backend_tools code path.
+
+        Patches _do_list_tools (transport layer) so the real list_backend_tools
+        runs its circuit breaker check.  The circuit-open backend never reaches
+        the transport; the healthy backend does.
+        """
         slack_url = "http://mcp-slack:8005/mcp"
-        atlassian_url = "http://mcp-atlassian:8021/mcp"
-        breaker.reset()
         for _ in range(3):
             breaker.record_failure(slack_url)
 
-        async def fake_list(backend_name: str, backend: Backend) -> list[dict[str, Any]]:
-            from mcp_trentina_crunchtools.gateway.circuit import breaker as cb
+        transport_calls: list[str] = []
 
-            if not cb.allow(backend.url):
-                from mcp_trentina_crunchtools.gateway.errors import BackendCallError
+        class _FakeToolsResult:
+            def __init__(self) -> None:
+                self.tools = [_FakeTool("jira_search")]
 
-                raise BackendCallError(f"backend {backend_name!r} circuit open — skipped")
-            return [{"name": "jira_search", "description": "", "inputSchema": {}}]
+        class _FakeTool:
+            def __init__(self, name: str) -> None:
+                self.name = name
+                self.description = ""
+                self.inputSchema: dict[str, Any] = {}
+
+        async def fake_transport(url: str, _headers: Any) -> _FakeToolsResult:
+            transport_calls.append(url)
+            return _FakeToolsResult()
 
         with patch(
-            "mcp_trentina_crunchtools.gateway.router.list_backend_tools",
-            side_effect=fake_list,
+            "mcp_trentina_crunchtools.gateway.backend._do_list_tools",
+            side_effect=fake_transport,
         ):
             resp = await route_jsonrpc(
                 _profile(), {"jsonrpc": "2.0", "id": 41, "method": "tools/list"}
             )
 
         names = [str(t["name"]) for t in resp["result"]["tools"]]
-        assert names == [f"mcp-atlassian{NAMESPACE_SEP}jira_search"]
-        breaker.reset(atlassian_url)
-        breaker.reset(slack_url)
+        assert f"mcp-atlassian{NAMESPACE_SEP}jira_search" in names
+        assert slack_url not in transport_calls
+        assert len(transport_calls) == 1
 
     async def test_tools_call_circuit_open_returns_error(self) -> None:
         """A tools/call to a circuit-open backend returns a JSON-RPC error immediately."""
         slack_url = "http://mcp-slack:8005/mcp"
-        breaker.reset()
         for _ in range(3):
             breaker.record_failure(slack_url)
 
@@ -520,4 +540,3 @@ class TestRouter:
         )
         assert resp["error"]["code"] == -32603
         assert "circuit open" in resp["error"]["message"]
-        breaker.reset()

--- a/tests/test_gateway_router.py
+++ b/tests/test_gateway_router.py
@@ -10,6 +10,7 @@ from pydantic import SecretStr
 
 from mcp_trentina_crunchtools.database import get_gateway_call_stats
 from mcp_trentina_crunchtools.gateway.backend import BackendCall
+from mcp_trentina_crunchtools.gateway.circuit import breaker
 from mcp_trentina_crunchtools.gateway.errors import BackendCallError, BackendNotInProfileError
 from mcp_trentina_crunchtools.gateway.profile import (
     AuthConfig,
@@ -446,3 +447,77 @@ class TestRouter:
             )
         assert called["tool"] == "send_gmail_message"
         assert resp["result"]["content"] == [{"type": "text", "text": "sent"}]
+
+    async def test_tools_list_parallel_all_healthy(self) -> None:
+        """Parallel fetch returns tools from all healthy backends."""
+        call_order: list[str] = []
+
+        async def fake_list(backend_name: str, _backend: Backend) -> list[dict[str, Any]]:
+            call_order.append(backend_name)
+            return [{"name": f"{backend_name}_tool", "description": "", "inputSchema": {}}]
+
+        with patch(
+            "mcp_trentina_crunchtools.gateway.router.list_backend_tools",
+            side_effect=fake_list,
+        ):
+            resp = await route_jsonrpc(
+                _profile(), {"jsonrpc": "2.0", "id": 40, "method": "tools/list"}
+            )
+
+        names = sorted(str(t["name"]) for t in resp["result"]["tools"])
+        assert f"mcp-atlassian{NAMESPACE_SEP}mcp-atlassian_tool" in names
+        assert f"mcp-slack{NAMESPACE_SEP}mcp-slack_tool" in names
+        assert len(call_order) == 2
+
+    async def test_tools_list_circuit_open_skips_immediately(self) -> None:
+        """A backend with an open circuit is skipped without blocking."""
+        slack_url = "http://mcp-slack:8005/mcp"
+        atlassian_url = "http://mcp-atlassian:8021/mcp"
+        breaker.reset()
+        for _ in range(3):
+            breaker.record_failure(slack_url)
+
+        async def fake_list(backend_name: str, backend: Backend) -> list[dict[str, Any]]:
+            from mcp_trentina_crunchtools.gateway.circuit import breaker as cb
+
+            if not cb.allow(backend.url):
+                from mcp_trentina_crunchtools.gateway.errors import BackendCallError
+
+                raise BackendCallError(f"backend {backend_name!r} circuit open — skipped")
+            return [{"name": "jira_search", "description": "", "inputSchema": {}}]
+
+        with patch(
+            "mcp_trentina_crunchtools.gateway.router.list_backend_tools",
+            side_effect=fake_list,
+        ):
+            resp = await route_jsonrpc(
+                _profile(), {"jsonrpc": "2.0", "id": 41, "method": "tools/list"}
+            )
+
+        names = [str(t["name"]) for t in resp["result"]["tools"]]
+        assert names == [f"mcp-atlassian{NAMESPACE_SEP}jira_search"]
+        breaker.reset(atlassian_url)
+        breaker.reset(slack_url)
+
+    async def test_tools_call_circuit_open_returns_error(self) -> None:
+        """A tools/call to a circuit-open backend returns a JSON-RPC error immediately."""
+        slack_url = "http://mcp-slack:8005/mcp"
+        breaker.reset()
+        for _ in range(3):
+            breaker.record_failure(slack_url)
+
+        resp = await route_jsonrpc(
+            _profile(),
+            {
+                "jsonrpc": "2.0",
+                "id": 42,
+                "method": "tools/call",
+                "params": {
+                    "name": f"mcp-slack{NAMESPACE_SEP}slack_list_channels",
+                    "arguments": {},
+                },
+            },
+        )
+        assert resp["error"]["code"] == -32603
+        assert "circuit open" in resp["error"]["message"]
+        breaker.reset()


### PR DESCRIPTION
## Summary

Fixes #36 — a single unreachable backend (e.g. `rotv`) blocked the entire gateway `tools/list` response, taking down all Trentina-connected Claude Code sessions.

**Three-part fix:**
- **Parallel backend fetching**: `asyncio.gather` replaces sequential `for` loop in `_route_tools_list`. Wall-clock time drops from sum-of-all-timeouts to max-of-healthy-backends (~200ms vs ~30s)
- **Circuit breaker**: per-URL state machine (closed → open → half-open → closed) that tracks consecutive failures. After 3 failures, immediately rejects calls for 60s cooldown instead of burning 30s timeout on every request
- **Separate list timeout**: new `list_timeout_seconds` field (default 10s) for lightweight metadata operations, distinct from the 30s operational `timeout_seconds`

## Files Changed

| File | Change |
|------|--------|
| `gateway/circuit.py` | **New** — circuit breaker state machine |
| `gateway/backend.py` | Circuit breaker checks + list timeout |
| `gateway/router.py` | `asyncio.gather` in `_route_tools_list` |
| `gateway/profile.py` | `list_timeout_seconds` field on `Backend` |
| `gateway/__init__.py` | Export circuit breaker |
| `tests/test_circuit_breaker.py` | **New** — 14 state machine tests |
| `tests/test_gateway_router.py` | 3 new tests (parallel, circuit open, call error) |
| `tests/test_gateway_profile.py` | 3 new tests (list_timeout validation) |

## Test plan

- [x] 14 circuit breaker state machine tests (all transitions, cooldown, independent URLs)
- [x] Parallel tools/list returns tools from all healthy backends
- [x] Circuit-open backend skipped immediately (no timeout wait)
- [x] tools/call to circuit-open backend returns JSON-RPC error
- [x] list_timeout_seconds Pydantic validation (default, custom, out-of-range)
- [x] All 399 existing tests pass (0 failures, 32 skipped)
- [x] Ruff clean
- [x] mypy: 2 pre-existing errors only (llm_proxy/matrix_proxy untyped decorators from #34)

🤖 Generated with [Claude Code](https://claude.com/claude-code)