### PR TITLE
fix: resolve all quality gate violations

### DIFF
--- a/cockpit-trentina/trentina.js
+++ b/cockpit-trentina/trentina.js
@@ -97,8 +97,8 @@
         document.body.innerHTML = html;
     }
 
-    function renderLayerStatus(data) {
-        var layers = JSON.parse(data);
+    function renderLayerStatus(layer_json) {
+        var layers = JSON.parse(layer_json);
         var el = document.getElementById("layer-status-body");
         if (!el) return;
 
@@ -117,8 +117,8 @@
             '</dl>';
     }
 
-    function renderStats(data) {
-        var info = JSON.parse(data);
+    function renderStats(stats_json) {
+        var info = JSON.parse(stats_json);
         var el = document.getElementById("blocklist-body");
         if (!el) return;
 
@@ -171,8 +171,8 @@
             tbody.removeChild(tbody.lastChild);
     }
 
-    function renderRecentEvents(data) {
-        var events = JSON.parse(data);
+    function renderRecentEvents(events_json) {
+        var events = JSON.parse(events_json);
         for (var i = 0; i < events.length; i++) {
             addEventRow(events[i], false);
         }

--- a/gourmand-exceptions.toml
+++ b/gourmand-exceptions.toml
@@ -146,7 +146,7 @@ justification = "classifier_result dict values are typed as Any — float() cast
 
 [[exceptions]]
 check = "generic_names"
-path = "cockpit-trentina/airlock.js"
+path = "cockpit-trentina/trentina.js"
 pattern = "data"
 justification = "D-Bus signal/callback handlers receive a generic payload object — 'data' is the Cockpit D-Bus API convention for response payloads"
 
@@ -157,49 +157,49 @@ justification = "D-Bus signal/callback handlers receive a generic payload object
 
 [[exceptions]]
 check = "single_use_helpers"
-path = "cockpit-trentina/airlock.js"
+path = "cockpit-trentina/trentina.js"
 pattern = "formatTime"
 justification = "UI display helper — semantic name clarifies intent in single-file Cockpit plugin"
 
 [[exceptions]]
 check = "single_use_helpers"
-path = "cockpit-trentina/airlock.js"
+path = "cockpit-trentina/trentina.js"
 pattern = "truncateSource"
 justification = "UI display helper — semantic name clarifies intent in single-file Cockpit plugin"
 
 [[exceptions]]
 check = "single_use_helpers"
-path = "cockpit-trentina/airlock.js"
+path = "cockpit-trentina/trentina.js"
 pattern = "scoreBar"
 justification = "UI display helper — generates HTML for L2 classifier score visualization"
 
 [[exceptions]]
 check = "single_use_helpers"
-path = "cockpit-trentina/airlock.js"
+path = "cockpit-trentina/trentina.js"
 pattern = "renderPage"
 justification = "UI lifecycle function — builds the initial DOM structure for the Cockpit panel"
 
 [[exceptions]]
 check = "single_use_helpers"
-path = "cockpit-trentina/airlock.js"
+path = "cockpit-trentina/trentina.js"
 pattern = "renderDetail"
 justification = "UI lifecycle function — populates pipeline detail card on event selection"
 
 [[exceptions]]
 check = "single_use_helpers"
-path = "cockpit-trentina/airlock.js"
+path = "cockpit-trentina/trentina.js"
 pattern = "setupSignals"
 justification = "UI lifecycle function — registers D-Bus signal listeners for live event streaming"
 
 [[exceptions]]
 check = "single_use_helpers"
-path = "cockpit-trentina/airlock.js"
+path = "cockpit-trentina/trentina.js"
 pattern = "showDetectionAlert"
 justification = "UI lifecycle function — creates and auto-dismisses PatternFly alert banners for injection detections"
 
 [[exceptions]]
 check = "single_use_helpers"
-path = "cockpit-trentina/airlock.js"
+path = "cockpit-trentina/trentina.js"
 pattern = "init"
 justification = "UI lifecycle function — entry point that orchestrates page render, D-Bus connection, and signal setup"
 
@@ -226,3 +226,15 @@ check = "lint_suppression"
 path = "src/mcp_trentina_crunchtools/gateway/app.py"
 pattern = "type: ignore"
 justification = "FastMCP's custom_route decorator has no type stubs; the [misc] ignore is the standard pattern for typed code calling into untyped framework APIs"
+
+[[exceptions]]
+check = "summary_litter"
+path = "deprecation/README.md"
+pattern = "README.md"
+justification = "PyPI requires README.md in the deprecation shim package — it tells users the package was renamed to mcp-trentina-crunchtools"
+
+[[exceptions]]
+check = "lint_suppression"
+path = "deprecation/src/mcp_airlock_crunchtools/__init__.py"
+pattern = "noqa: F401,F403"
+justification = "Wildcard re-export is the entire purpose of the deprecation shim — it forwards all public names from the renamed package"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ max-statements = 50
 "src/mcp_trentina_crunchtools/gateway/app.py" = ["C901", "PLR0911", "PLR0912"]
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.12"
 strict = true
 warn_return_any = true
 warn_unused_configs = true

--- a/src/mcp_trentina_crunchtools/gateway/compress.py
+++ b/src/mcp_trentina_crunchtools/gateway/compress.py
@@ -114,21 +114,21 @@ def compress_tools(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
     if not _cache:
         return tools
 
-    result: list[dict[str, Any]] = []
+    compressed_tools: list[dict[str, Any]] = []
     for tool in tools:
         desc = tool.get("description", "")
         if not desc:
-            result.append(tool)
+            compressed_tools.append(tool)
             continue
         h = _hash_description(desc)
         compressed = _cache.get(h)
         if compressed is not None:
             tool_copy = dict(tool)
             tool_copy["description"] = compressed
-            result.append(tool_copy)
+            compressed_tools.append(tool_copy)
         else:
-            result.append(tool)
-    return result
+            compressed_tools.append(tool)
+    return compressed_tools
 
 
 async def precompress_all(
@@ -295,10 +295,10 @@ async def _call_compress_model(
     return []
 
 
-def _parse_compress_response(data: dict[str, Any]) -> list[tuple[str, str]]:
+def _parse_compress_response(gemini_response: dict[str, Any]) -> list[tuple[str, str]]:
     """Extract compressed descriptions from a Gemini API response."""
     try:
-        candidates = data.get("candidates", [])
+        candidates = gemini_response.get("candidates", [])
         if not candidates:
             logger.warning("compress: Gemini returned no candidates")
             return []

--- a/src/mcp_trentina_crunchtools/gateway/llm_proxy.py
+++ b/src/mcp_trentina_crunchtools/gateway/llm_proxy.py
@@ -29,6 +29,8 @@ from starlette.responses import Response, StreamingResponse
 from .errors import ProfileConfigError
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
     from starlette.requests import Request
 
 logger = logging.getLogger(__name__)
@@ -140,11 +142,12 @@ def register_llm_routes(
     if not providers:
         return
 
-    @mcp_server.custom_route(  # type: ignore[untyped-decorator]
-        "/llm/{provider}/{path:path}", methods=_LLM_METHODS,
-    )
     async def llm_proxy_endpoint(request: Request) -> Response:
         return await _proxy_llm(request, providers)
+
+    mcp_server.custom_route(
+        "/llm/{provider}/{path:path}", methods=_LLM_METHODS,
+    )(llm_proxy_endpoint)
 
     logger.info(
         "llm_proxy: registered /llm/{provider}/{path} "
@@ -220,7 +223,7 @@ def _streaming_response(resp: httpx.Response) -> StreamingResponse:
         if k.lower() not in _STRIP_RESPONSE_HEADERS
     }
 
-    async def body():  # type: ignore[no-untyped-def]
+    async def stream_body() -> AsyncIterator[bytes]:
         try:
             async for chunk in resp.aiter_bytes():
                 yield chunk
@@ -229,6 +232,6 @@ def _streaming_response(resp: httpx.Response) -> StreamingResponse:
 
     ct = resp.headers.get("content-type", "application/json")
     return StreamingResponse(
-        body(), status_code=resp.status_code,
+        stream_body(), status_code=resp.status_code,
         headers=resp_headers, media_type=ct,
     )

--- a/src/mcp_trentina_crunchtools/gateway/matrix_proxy.py
+++ b/src/mcp_trentina_crunchtools/gateway/matrix_proxy.py
@@ -18,6 +18,8 @@ import httpx
 from starlette.responses import Response, StreamingResponse
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
     from starlette.requests import Request
 
 logger = logging.getLogger(__name__)
@@ -62,11 +64,12 @@ def register_matrix_routes(
         )
     upstream = upstream.rstrip("/")
 
-    @mcp_server.custom_route(  # type: ignore[untyped-decorator]
-        "/matrix/{path:path}", methods=_MATRIX_METHODS,
-    )
     async def matrix_proxy_endpoint(request: Request) -> Response:
         return await _proxy_matrix(request, upstream)
+
+    mcp_server.custom_route(
+        "/matrix/{path:path}", methods=_MATRIX_METHODS,
+    )(matrix_proxy_endpoint)
 
     logger.info(
         "matrix_proxy: registered /matrix/{path} → %s", upstream,
@@ -114,7 +117,7 @@ async def _proxy_matrix(request: Request, upstream: str) -> Response:
         if k.lower() not in _STRIP_RESPONSE_HEADERS
     }
 
-    async def body_stream():  # type: ignore[no-untyped-def]
+    async def stream_body() -> AsyncIterator[bytes]:
         try:
             async for chunk in resp.aiter_bytes():
                 yield chunk
@@ -123,6 +126,6 @@ async def _proxy_matrix(request: Request, upstream: str) -> Response:
 
     ct = resp.headers.get("content-type", "application/json")
     return StreamingResponse(
-        body_stream(), status_code=resp.status_code,
+        stream_body(), status_code=resp.status_code,
         headers=resp_headers, media_type=ct,
     )


### PR DESCRIPTION
## Summary

Fixes #34 — all five constitution-required quality gates now pass in CI.

**mypy** (1 error → 0):
- Bump `python_version` from `"3.10"` to `"3.12"` to fix numpy stub syntax error (stubs use Python 3.12 `type` statement)

**Gourmand** (19 violations → 0):
- **lint_suppression** (5→0): Add `AsyncIterator` return type to streaming generators, use function-call style for `custom_route()`, add deprecation shim exception
- **generic_names** (5→0): Rename `result`→`compressed_tools`, `data`→`gemini_response` in compress.py; `data`→domain-specific names in trentina.js
- **single_use_helpers** (8→0): Fix exception paths from `airlock.js` to `trentina.js`
- **summary_litter** (1→0): Add `deprecation/README.md` exception

## Test plan

- [x] `uv run ruff check src tests` — clean
- [x] `uv run mypy src` — 0 errors (was 1)
- [x] `uv run pytest -v` — 408 passed, 32 skipped, 0 failed
- [x] `gourmand --full .` — 0 violations (was 19)
- [ ] CI container build

🤖 Generated with [Claude Code](https://claude.com/claude-code)