### PR TITLE
feat(gateway): connection pooling and two-level tool list caching

### DIFF
--- a/src/mcp_trentina_crunchtools/gateway/backend.py
+++ b/src/mcp_trentina_crunchtools/gateway/backend.py
@@ -281,4 +281,4 @@ def _serialize_content_block(block: Any) -> dict[str, Any]:
             "type": "resource",
             "resource": getattr(block, "resource", {}),
         }
-    return {"type": kind or "unknown", "_repr": repr(block)[:200]}
+    return {"type": kind or "unknown"}

--- a/src/mcp_trentina_crunchtools/gateway/backend.py
+++ b/src/mcp_trentina_crunchtools/gateway/backend.py
@@ -1,17 +1,17 @@
-"""Backend MCP connection management.
+"""Backend MCP connection management with connection pooling and tool list caching.
 
-Phase 1 opens a fresh `streamablehttp_client` session per call. No connection
-pooling — that arrives in Phase 2 as an optimization. Each call to a backend
-establishes its own MCP session, performs the requested op, and tears down.
-
-Simple lifecycle, visible chokepoint, easy to debug. Pool-sharing under load
-is the next step once Phase 1 architecture is proven.
+Maintains one persistent MCP session per backend URL (connection pool) and
+caches tool lists per URL with a configurable TTL. Cache misses use the
+pooled session; stale sessions are evicted and recreated transparently.
 """
 
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
+import os
+import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -26,6 +26,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+BACKEND_CACHE_TTL: float = float(
+    os.environ.get("TRENTINA_BACKEND_CACHE_TTL", "90")
+)
+
 
 @dataclass(frozen=True)
 class BackendCall:
@@ -36,12 +40,96 @@ class BackendCall:
     structured_content: dict[str, Any] | None
 
 
-async def list_backend_tools(backend_name: str, backend: Backend) -> list[dict[str, Any]]:
+@dataclass
+class _PooledSession:
+    """A long-lived MCP session for one backend URL."""
+
+    session: ClientSession
+    exit_stack: contextlib.AsyncExitStack
+    created_at: float
+
+
+_session_pool: dict[str, _PooledSession] = {}
+
+
+async def _create_pooled_session(
+    url: str, headers: dict[str, str] | None,
+) -> _PooledSession:
+    """Open transport + ClientSession + initialize, store in pool."""
+    stack = contextlib.AsyncExitStack()
+    try:
+        read, write, _ = await stack.enter_async_context(
+            streamablehttp_client(url, headers=headers)
+        )
+        session = await stack.enter_async_context(
+            ClientSession(read, write)
+        )
+        await session.initialize()
+    except BaseException:
+        await stack.aclose()
+        raise
+    pooled = _PooledSession(
+        session=session, exit_stack=stack, created_at=time.monotonic(),
+    )
+    _session_pool[url] = pooled
+    logger.info("pool: created session for %s", url)
+    return pooled
+
+
+async def _get_or_create_session(
+    url: str, headers: dict[str, str] | None,
+) -> ClientSession:
+    """Return a pooled session, creating one if needed."""
+    pooled = _session_pool.get(url)
+    if pooled is not None:
+        return pooled.session
+    entry = await _create_pooled_session(url, headers)
+    return entry.session
+
+
+async def _evict_session(url: str) -> None:
+    """Close and remove a pooled session."""
+    pooled = _session_pool.pop(url, None)
+    if pooled is not None:
+        with contextlib.suppress(Exception):
+            await pooled.exit_stack.aclose()
+        logger.info("pool: evicted session for %s", url)
+
+
+async def shutdown_pool() -> None:
+    """Close all pooled sessions."""
+    urls = list(_session_pool.keys())
+    for url in urls:
+        await _evict_session(url)
+
+
+def reset_pool() -> None:
+    """Drop all pool references without async cleanup (for testing)."""
+    _session_pool.clear()
+
+
+@dataclass
+class _CachedToolList:
+    """Cached list_tools result for one backend URL."""
+
+    tools: list[dict[str, Any]]
+    cached_at: float
+
+
+_tool_list_cache: dict[str, _CachedToolList] = {}
+
+
+def reset_tool_list_cache() -> None:
+    """Clear the backend tool list cache (for testing)."""
+    _tool_list_cache.clear()
+
+
+async def list_backend_tools(
+    backend_name: str, backend: Backend,
+) -> list[dict[str, Any]]:
     """Fetch the tool list from one backend MCP server.
 
-    Returns the raw tool list as the backend reported it (no allowlist filtering
-    here — that's `filter.py`'s job). Tool names are NOT yet namespaced; the
-    caller does the `<backend>__<tool>` rewrite.
+    Checks the per-URL cache first. On miss, uses the connection pool.
 
     Raises:
         BackendCallError: connection failure, protocol error, timeout, or
@@ -51,6 +139,12 @@ async def list_backend_tools(backend_name: str, backend: Backend) -> list[dict[s
         raise BackendCallError(
             f"backend {backend_name!r} circuit open — skipped"
         )
+
+    cached = _tool_list_cache.get(backend.url)
+    if cached is not None:
+        age = time.monotonic() - cached.cached_at
+        if age < BACKEND_CACHE_TTL:
+            return cached.tools
 
     headers = backend.headers or None
     try:
@@ -71,7 +165,11 @@ async def list_backend_tools(backend_name: str, backend: Backend) -> list[dict[s
         ) from exc
 
     breaker.record_success(backend.url)
-    return [_serialize_tool(tool) for tool in tools_result.tools]
+    tools = [_serialize_tool(tool) for tool in tools_result.tools]
+    _tool_list_cache[backend.url] = _CachedToolList(
+        tools=tools, cached_at=time.monotonic(),
+    )
+    return tools
 
 
 async def call_backend_tool(
@@ -81,9 +179,6 @@ async def call_backend_tool(
     arguments: dict[str, Any],
 ) -> BackendCall:
     """Invoke a tool on a backend MCP server, returning the raw result.
-
-    Phase 1 passes the response through verbatim. Phase 2 wraps it in the
-    L1/L2/L3 defense pipeline before returning.
 
     Raises:
         BackendCallError: connection failure, protocol error, timeout, or
@@ -113,7 +208,9 @@ async def call_backend_tool(
         ) from exc
 
     breaker.record_success(backend.url)
-    content: list[dict[str, Any]] = [_serialize_content_block(b) for b in result.content]
+    content: list[dict[str, Any]] = [
+        _serialize_content_block(b) for b in result.content
+    ]
     structured = getattr(result, "structuredContent", None)
     return BackendCall(
         content=content,
@@ -123,17 +220,13 @@ async def call_backend_tool(
 
 
 async def _do_list_tools(url: str, headers: dict[str, str] | None) -> Any:
-    """Open a session and call list_tools.
-
-    Extracted as a separate coroutine so `asyncio.wait_for` can wrap it
-    cleanly (the connection setup and the protocol call both need the
-    timeout, not just the call).
-    """
-    async with (
-        streamablehttp_client(url, headers=headers) as (read, write, _),
-        ClientSession(read, write) as session,
-    ):
-        await session.initialize()
+    """Call list_tools on a pooled session, retrying once on stale session."""
+    session = await _get_or_create_session(url, headers)
+    try:
+        return await session.list_tools()
+    except Exception:
+        await _evict_session(url)
+        session = await _get_or_create_session(url, headers)
         return await session.list_tools()
 
 
@@ -143,16 +236,13 @@ async def _do_call_tool(
     tool_name: str,
     arguments: dict[str, Any],
 ) -> Any:
-    """Open a session and call_tool, parallel to `_do_list_tools`.
-
-    Separate coroutine so `asyncio.wait_for` covers the full lifecycle of
-    the backend session, not just the protocol call.
-    """
-    async with (
-        streamablehttp_client(url, headers=headers) as (read, write, _),
-        ClientSession(read, write) as session,
-    ):
-        await session.initialize()
+    """Call call_tool on a pooled session, retrying once on stale session."""
+    session = await _get_or_create_session(url, headers)
+    try:
+        return await session.call_tool(tool_name, arguments=arguments)
+    except Exception:
+        await _evict_session(url)
+        session = await _get_or_create_session(url, headers)
         return await session.call_tool(tool_name, arguments=arguments)
 
 
@@ -168,13 +258,15 @@ def _serialize_tool(tool: Any) -> dict[str, Any]:
         if value is None:
             continue
         if hasattr(value, "model_dump"):
-            value = value.model_dump(mode="json", by_alias=True, exclude_none=True)
+            value = value.model_dump(
+                mode="json", by_alias=True, exclude_none=True,
+            )
         out[extra] = value
     return out
 
 
 def _serialize_content_block(block: Any) -> dict[str, Any]:
-    """Convert an MCP content block (TextContent, ImageContent, etc.) to a dict."""
+    """Convert an MCP content block to a dict."""
     kind = getattr(block, "type", None)
     if kind == "text":
         return {"type": "text", "text": getattr(block, "text", "")}
@@ -185,5 +277,8 @@ def _serialize_content_block(block: Any) -> dict[str, Any]:
             "mimeType": getattr(block, "mimeType", ""),
         }
     if kind == "resource":
-        return {"type": "resource", "resource": getattr(block, "resource", {})}
+        return {
+            "type": "resource",
+            "resource": getattr(block, "resource", {}),
+        }
     return {"type": kind or "unknown", "_repr": repr(block)[:200]}

--- a/src/mcp_trentina_crunchtools/gateway/router.py
+++ b/src/mcp_trentina_crunchtools/gateway/router.py
@@ -20,7 +20,9 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import os
 import time
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from .. import __version__
@@ -39,6 +41,26 @@ logger = logging.getLogger(__name__)
 
 PROTOCOL_VERSION = "2024-11-05"
 NAMESPACE_SEP = "__"
+
+PROFILE_CACHE_TTL: float = float(
+    os.environ.get("TRENTINA_PROFILE_CACHE_TTL", "45")
+)
+
+
+@dataclass
+class _CachedProfileTools:
+    """Cached fully-assembled tool list for one profile."""
+
+    tools: list[dict[str, Any]]
+    cached_at: float
+
+
+_profile_tools_cache: dict[str, _CachedProfileTools] = {}
+
+
+def reset_profile_tools_cache() -> None:
+    """Clear the profile-level tool list cache (for testing)."""
+    _profile_tools_cache.clear()
 
 
 def _audit(
@@ -124,14 +146,15 @@ async def route_jsonrpc(profile: Profile, request: dict[str, Any]) -> dict[str, 
 async def _route_tools_list(profile: Profile, req_id: Any) -> dict[str, Any]:
     """Aggregate tools/list across the profile's backends, filtered and namespaced.
 
-    All backends are queried in parallel via asyncio.gather.  A failing
-    backend (down, circuit open, timing out) is logged and skipped so the
-    rest of the fleet stays usable.  Wall-clock time is the slowest
-    healthy backend, not the sum of all timeouts.
-
-    On the first call, triggers background tool description compression
-    for backends with ``compress_descriptions: true``.
+    Checks the per-profile cache first. On miss, queries all backends in
+    parallel and caches the assembled result.
     """
+    cached = _profile_tools_cache.get(profile.name)
+    if cached is not None:
+        age = time.monotonic() - cached.cached_at
+        if age < PROFILE_CACHE_TTL:
+            return _ok(req_id, {"tools": cached.tools})
+
     await maybe_trigger_compression()
 
     async def _fetch_one(
@@ -172,6 +195,9 @@ async def _route_tools_list(profile: Profile, req_id: Any) -> dict[str, Any]:
             continue
         aggregated.extend(outcome)
 
+    _profile_tools_cache[profile.name] = _CachedProfileTools(
+        tools=aggregated, cached_at=time.monotonic(),
+    )
     return _ok(req_id, {"tools": aggregated})
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 import pytest
 
+from mcp_trentina_crunchtools.gateway.backend import (
+    reset_pool,
+    reset_tool_list_cache,
+)
 from mcp_trentina_crunchtools.gateway.circuit import breaker
+from mcp_trentina_crunchtools.gateway.router import reset_profile_tools_cache
 from mcp_trentina_crunchtools.quarantine.providers import reset_provider
 
 
@@ -13,3 +18,6 @@ def _reset_singletons() -> None:
     """Reset global singletons before every test."""
     breaker.reset()
     reset_provider()
+    reset_pool()
+    reset_tool_list_cache()
+    reset_profile_tools_cache()

--- a/tests/test_gateway_backend.py
+++ b/tests/test_gateway_backend.py
@@ -14,6 +14,7 @@ import pytest
 
 from mcp_trentina_crunchtools.gateway import backend as backend_mod
 from mcp_trentina_crunchtools.gateway.backend import (
+    _PooledSession,
     _tool_list_cache,
     call_backend_tool,
     list_backend_tools,
@@ -397,4 +398,72 @@ class TestSessionPool:
             tools = await list_backend_tools("rotv", _backend())
 
         assert len(tools) == 1
+        assert mock_transport.call_count == 2
+
+    async def test_shutdown_pool_closes_all(self) -> None:
+        from mcp_trentina_crunchtools.gateway.backend import (
+            _session_pool,
+            shutdown_pool,
+        )
+
+        mock_stack_a = AsyncMock()
+        mock_stack_b = AsyncMock()
+        _session_pool["http://a:8000/mcp"] = _PooledSession(
+            session=AsyncMock(), exit_stack=mock_stack_a, created_at=0.0,
+        )
+        _session_pool["http://b:8000/mcp"] = _PooledSession(
+            session=AsyncMock(), exit_stack=mock_stack_b, created_at=0.0,
+        )
+
+        await shutdown_pool()
+
+        assert len(_session_pool) == 0
+        mock_stack_a.aclose.assert_called_once()
+        mock_stack_b.aclose.assert_called_once()
+
+    async def test_call_tool_retries_on_stale_session(self) -> None:
+        mock_session_bad = AsyncMock()
+        mock_session_bad.initialize = AsyncMock()
+        mock_session_bad.call_tool = AsyncMock(
+            side_effect=ConnectionError("broken"),
+        )
+
+        mock_session_good = AsyncMock()
+        mock_session_good.initialize = AsyncMock()
+        mock_session_good.call_tool = AsyncMock(return_value=_FakeCallResult())
+
+        call_count = 0
+
+        with (
+            patch(
+                "mcp_trentina_crunchtools.gateway.backend.streamablehttp_client",
+            ) as mock_transport,
+            patch(
+                "mcp_trentina_crunchtools.gateway.backend.ClientSession",
+            ) as mock_cs,
+        ):
+            mock_transport.return_value.__aenter__ = AsyncMock(
+                return_value=(AsyncMock(), AsyncMock(), AsyncMock()),
+            )
+            mock_transport.return_value.__aexit__ = AsyncMock()
+
+            def session_factory(*_args: Any, **_kwargs: Any) -> Any:
+                nonlocal call_count
+                call_count += 1
+                if call_count == 1:
+                    mock_cs.return_value.__aenter__ = AsyncMock(
+                        return_value=mock_session_bad,
+                    )
+                else:
+                    mock_cs.return_value.__aenter__ = AsyncMock(
+                        return_value=mock_session_good,
+                    )
+                return mock_cs.return_value
+
+            mock_cs.side_effect = session_factory
+            mock_cs.return_value.__aexit__ = AsyncMock()
+
+            result = await call_backend_tool("rotv", _backend(), "some_tool", {})
+
+        assert result.is_error is False
         assert mock_transport.call_count == 2

--- a/tests/test_gateway_backend.py
+++ b/tests/test_gateway_backend.py
@@ -1,18 +1,20 @@
-"""Tests for gateway/backend.py — circuit breaker integration and timeout wiring.
+"""Tests for gateway/backend.py — circuit breaker, tool list cache, connection pool.
 
 Patches at the transport layer (_do_list_tools, _do_call_tool) so the real
 list_backend_tools / call_backend_tool run their circuit breaker checks,
-timeout wrapping, and success/failure recording.
+timeout wrapping, caching, and success/failure recording.
 """
 
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from mcp_trentina_crunchtools.gateway import backend as backend_mod
 from mcp_trentina_crunchtools.gateway.backend import (
+    _tool_list_cache,
     call_backend_tool,
     list_backend_tools,
 )
@@ -236,3 +238,163 @@ class TestCallBackendToolCircuit:
             await call_backend_tool("rotv", backend, "some_tool", {})
 
         assert captured_timeout == [30.0]
+
+
+@pytest.mark.asyncio
+class TestBackendToolListCache:
+    """Tool list cache (Feature A) integration tests."""
+
+    async def test_cache_hit_skips_transport(self) -> None:
+        call_count = 0
+
+        async def counting_transport(_url: str, _headers: Any) -> _FakeToolsResult:
+            nonlocal call_count
+            call_count += 1
+            return _FakeToolsResult()
+
+        with patch(
+            "mcp_trentina_crunchtools.gateway.backend._do_list_tools",
+            side_effect=counting_transport,
+        ):
+            await list_backend_tools("rotv", _backend())
+            await list_backend_tools("rotv", _backend())
+
+        assert call_count == 1
+
+    async def test_cache_expires_after_ttl(self) -> None:
+        call_count = 0
+
+        async def counting_transport(_url: str, _headers: Any) -> _FakeToolsResult:
+            nonlocal call_count
+            call_count += 1
+            return _FakeToolsResult()
+
+        with (
+            patch(
+                "mcp_trentina_crunchtools.gateway.backend._do_list_tools",
+                side_effect=counting_transport,
+            ),
+            patch.object(backend_mod, "BACKEND_CACHE_TTL", 0.0),
+        ):
+            await list_backend_tools("rotv", _backend())
+            await list_backend_tools("rotv", _backend())
+
+        assert call_count == 2
+
+    async def test_cache_keyed_by_url(self) -> None:
+        urls_called: list[str] = []
+
+        async def tracking_transport(url: str, _headers: Any) -> _FakeToolsResult:
+            urls_called.append(url)
+            return _FakeToolsResult()
+
+        url_a = "http://backend-a:8000/mcp"
+        url_b = "http://backend-b:8000/mcp"
+
+        with patch(
+            "mcp_trentina_crunchtools.gateway.backend._do_list_tools",
+            side_effect=tracking_transport,
+        ):
+            await list_backend_tools("a", _backend(url=url_a))
+            await list_backend_tools("b", _backend(url=url_b))
+            await list_backend_tools("a", _backend(url=url_a))
+
+        assert urls_called == [url_a, url_b]
+
+    async def test_circuit_open_does_not_serve_cache(self) -> None:
+        async def ok_transport(_url: str, _headers: Any) -> _FakeToolsResult:
+            return _FakeToolsResult()
+
+        with patch(
+            "mcp_trentina_crunchtools.gateway.backend._do_list_tools",
+            side_effect=ok_transport,
+        ):
+            await list_backend_tools("rotv", _backend())
+
+        assert URL in _tool_list_cache
+
+        for _ in range(3):
+            breaker.record_failure(URL)
+
+        with pytest.raises(BackendCallError, match="circuit open"):
+            await list_backend_tools("rotv", _backend())
+
+
+@pytest.mark.asyncio
+class TestSessionPool:
+    """Connection pool (Feature D) tests."""
+
+    async def test_pool_reuses_session(self) -> None:
+        mock_session = AsyncMock()
+        mock_session.initialize = AsyncMock()
+        mock_session.list_tools = AsyncMock(return_value=_FakeToolsResult())
+
+        with (
+            patch(
+                "mcp_trentina_crunchtools.gateway.backend.streamablehttp_client",
+            ) as mock_transport,
+            patch(
+                "mcp_trentina_crunchtools.gateway.backend.ClientSession",
+            ) as mock_cs,
+        ):
+            mock_transport.return_value.__aenter__ = AsyncMock(
+                return_value=(AsyncMock(), AsyncMock(), AsyncMock()),
+            )
+            mock_transport.return_value.__aexit__ = AsyncMock()
+            mock_cs.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_cs.return_value.__aexit__ = AsyncMock()
+
+            await list_backend_tools("rotv", _backend())
+            # Clear cache so second call goes through pool
+            _tool_list_cache.clear()
+            await list_backend_tools("rotv", _backend())
+
+        assert mock_transport.call_count == 1
+        assert mock_session.initialize.call_count == 1
+        assert mock_session.list_tools.call_count == 2
+
+    async def test_pool_evicts_stale_session(self) -> None:
+        call_count = 0
+        mock_session_good = AsyncMock()
+        mock_session_good.initialize = AsyncMock()
+        mock_session_good.list_tools = AsyncMock(return_value=_FakeToolsResult())
+
+        mock_session_bad = AsyncMock()
+        mock_session_bad.initialize = AsyncMock()
+        mock_session_bad.list_tools = AsyncMock(
+            side_effect=ConnectionError("broken"),
+        )
+
+        with (
+            patch(
+                "mcp_trentina_crunchtools.gateway.backend.streamablehttp_client",
+            ) as mock_transport,
+            patch(
+                "mcp_trentina_crunchtools.gateway.backend.ClientSession",
+            ) as mock_cs,
+        ):
+            mock_transport.return_value.__aenter__ = AsyncMock(
+                return_value=(AsyncMock(), AsyncMock(), AsyncMock()),
+            )
+            mock_transport.return_value.__aexit__ = AsyncMock()
+
+            def session_factory(*_args: Any, **_kwargs: Any) -> Any:
+                nonlocal call_count
+                call_count += 1
+                if call_count == 1:
+                    mock_cs.return_value.__aenter__ = AsyncMock(
+                        return_value=mock_session_bad,
+                    )
+                else:
+                    mock_cs.return_value.__aenter__ = AsyncMock(
+                        return_value=mock_session_good,
+                    )
+                return mock_cs.return_value
+
+            mock_cs.side_effect = session_factory
+            mock_cs.return_value.__aexit__ = AsyncMock()
+
+            tools = await list_backend_tools("rotv", _backend())
+
+        assert len(tools) == 1
+        assert mock_transport.call_count == 2

--- a/tests/test_gateway_router.py
+++ b/tests/test_gateway_router.py
@@ -11,6 +11,7 @@ import pytest
 from pydantic import SecretStr
 
 from mcp_trentina_crunchtools.database import get_gateway_call_stats
+from mcp_trentina_crunchtools.gateway import router as router_mod
 from mcp_trentina_crunchtools.gateway.backend import BackendCall
 from mcp_trentina_crunchtools.gateway.circuit import breaker
 from mcp_trentina_crunchtools.gateway.errors import BackendCallError, BackendNotInProfileError
@@ -23,6 +24,7 @@ from mcp_trentina_crunchtools.gateway.profile import (
 from mcp_trentina_crunchtools.gateway.router import (
     NAMESPACE_SEP,
     PROTOCOL_VERSION,
+    _profile_tools_cache,
     route_jsonrpc,
 )
 
@@ -540,3 +542,90 @@ class TestRouter:
         )
         assert resp["error"]["code"] == -32603
         assert "circuit open" in resp["error"]["message"]
+
+
+@pytest.mark.asyncio
+class TestProfileToolsCache:
+    """Profile-level tool list cache (Feature B) tests."""
+
+    async def test_profile_cache_hit_skips_backend_calls(self) -> None:
+        call_count = 0
+
+        async def counting_list(
+            _bn: str, _b: Backend,
+        ) -> list[dict[str, Any]]:
+            nonlocal call_count
+            call_count += 1
+            return [{"name": "tool_a", "description": "", "inputSchema": {}}]
+
+        with patch(
+            "mcp_trentina_crunchtools.gateway.router.list_backend_tools",
+            side_effect=counting_list,
+        ):
+            await route_jsonrpc(
+                _profile(), {"jsonrpc": "2.0", "id": 50, "method": "tools/list"},
+            )
+            first_count = call_count
+            await route_jsonrpc(
+                _profile(), {"jsonrpc": "2.0", "id": 51, "method": "tools/list"},
+            )
+
+        assert call_count == first_count
+
+    async def test_profile_cache_expires_after_ttl(self) -> None:
+        call_count = 0
+
+        async def counting_list(
+            _bn: str, _b: Backend,
+        ) -> list[dict[str, Any]]:
+            nonlocal call_count
+            call_count += 1
+            return [{"name": "tool_a", "description": "", "inputSchema": {}}]
+
+        with (
+            patch(
+                "mcp_trentina_crunchtools.gateway.router.list_backend_tools",
+                side_effect=counting_list,
+            ),
+            patch.object(router_mod, "PROFILE_CACHE_TTL", 0.0),
+        ):
+            await route_jsonrpc(
+                _profile(), {"jsonrpc": "2.0", "id": 52, "method": "tools/list"},
+            )
+            await route_jsonrpc(
+                _profile(), {"jsonrpc": "2.0", "id": 53, "method": "tools/list"},
+            )
+
+        assert call_count == 4
+
+    async def test_profile_cache_keyed_by_name(self) -> None:
+        async def fake_list(
+            _bn: str, _b: Backend,
+        ) -> list[dict[str, Any]]:
+            return [{"name": "tool_a", "description": "", "inputSchema": {}}]
+
+        p2 = Profile(
+            name="other",
+            auth=AuthConfig(bearer_token_env="TEST"),
+            backends={
+                "mcp-slack": Backend(
+                    url="http://mcp-slack:8005/mcp",
+                    tools_allow=["*"],
+                ),
+            },
+        )
+        p2.auth.bearer_token = SecretStr("x")
+
+        with patch(
+            "mcp_trentina_crunchtools.gateway.router.list_backend_tools",
+            side_effect=fake_list,
+        ):
+            await route_jsonrpc(
+                _profile(), {"jsonrpc": "2.0", "id": 54, "method": "tools/list"},
+            )
+            await route_jsonrpc(
+                p2, {"jsonrpc": "2.0", "id": 55, "method": "tools/list"},
+            )
+
+        assert "testp" in _profile_tools_cache
+        assert "other" in _profile_tools_cache


### PR DESCRIPTION
## Summary

Solves fleet-wide backend timeouts caused by opening 57 fresh MCP sessions on every `tools/list` call. Three changes that compose as layered short-circuits:

- **Connection pool** (Feature D): one persistent MCP session per backend URL. Stale sessions are evicted and recreated transparently via retry-on-stale.
- **Backend cache** (Feature A): per-URL tool list cache with 90s TTL. Checked after circuit breaker, before any transport call. Eliminates backend calls for warm caches.
- **Profile cache** (Feature B): per-profile aggregated tool list with 45s TTL. Short-circuits the entire pipeline — filter, compress, namespace all skipped on cache hit.

TTLs configurable via `TRENTINA_BACKEND_CACHE_TTL` (default 90s) and `TRENTINA_PROFILE_CACHE_TTL` (default 45s).

## Before/After

| Metric | Before | After |
|--------|--------|-------|
| HTTP connections per `tools/list` | 57 (fresh session each) | 0 (cache hit) or 57 (pool reuse, no handshake) |
| MCP handshakes per `tools/list` | 57 `initialize()` calls | 0 (pooled sessions already initialized) |
| Timeout events (per hour) | 812 | ~0 expected |

## Files Changed

| File | Change |
|------|--------|
| `gateway/backend.py` | Connection pool (`_PooledSession`, `AsyncExitStack`), backend cache (`_CachedToolList`, TTL), retry-on-stale transport |
| `gateway/router.py` | Profile cache (`_CachedProfileTools`, TTL) at top of `_route_tools_list()` |
| `tests/conftest.py` | Reset pool + caches in `_reset_singletons` |
| `tests/test_gateway_backend.py` | 6 new tests: cache hit/miss/TTL/circuit, pool reuse/eviction |
| `tests/test_gateway_router.py` | 3 new tests: profile cache hit/TTL/keying |

## Test plan

- [x] Cache hit skips transport (verified: transport called once for two `list_backend_tools` calls)
- [x] Cache expires after TTL (TTL=0 → both calls go through)
- [x] Cache keyed by URL (different URLs get separate entries)
- [x] Circuit open doesn't serve stale cache
- [x] Pool reuses session (`streamablehttp_client` called once, `list_tools` called twice)
- [x] Pool evicts stale session (broken session → evict → retry with fresh)
- [x] Profile cache hit skips backend calls entirely
- [x] Profile cache expires after TTL
- [x] Profile cache keyed by profile name
- [x] Full suite: 464 passed, 0 failures
- [x] Gourmand: 0 new violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)