### PR TITLE
feat: deliver tools/listChanged to agents over SSE on circuit state change (#44)

### DIFF
--- a/src/mcp_trentina_crunchtools/gateway/app.py
+++ b/src/mcp_trentina_crunchtools/gateway/app.py
@@ -15,12 +15,13 @@ notifications (e.g. ``tools/listChanged`` on circuit breaker state changes).
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from typing import TYPE_CHECKING, Any
 
 from starlette.applications import Starlette
-from starlette.responses import JSONResponse, Response
+from starlette.responses import JSONResponse, Response, StreamingResponse
 from starlette.routing import Route
 
 from .auth import verify_bearer
@@ -35,6 +36,8 @@ from .router import route_jsonrpc
 from .sessions import SessionRegistry, session_registry
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
     from starlette.requests import Request
 
     from .profile import Profile
@@ -42,6 +45,14 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 MCP_SESSION_ID_HEADER = "mcp-session-id"
+
+SSE_KEEPALIVE_SECONDS = 25.0
+"""Idle gap between keepalive frames. Under common proxy/gateway idle
+timeouts (~60s) so quiet connections don't hit 504 upstream-timeout drops."""
+
+SSE_RETRY_MS = 15000
+"""Reconnect hint (ms) sent on stream open. Standard SSE clients honour
+``retry:`` and back off at the protocol layer, bypassing app-level retry caps."""
 
 
 def gateway_app(
@@ -95,16 +106,13 @@ async def _handle_get(
     registry: dict[str, Profile],
     sessions: SessionRegistry,
 ) -> Response:
-    """Open an SSE stream for server-push notifications.
+    """Open a long-lived SSE stream for server-push notifications.
 
     Requires a valid ``Mcp-Session-Id`` header.  The stream stays open
-    until the client disconnects; ``tools/listChanged`` notifications
-    are pushed when circuit breaker state affects this session's profile.
-
-    Phase 2 implementation: validates the session exists and returns 200
-    with an ``text/event-stream`` content type.  Actual long-lived SSE
-    streaming requires an ASGI streaming response that will be connected
-    to the session notification pipeline in a follow-up.
+    until the client disconnects; ``notifications/tools/listChanged`` frames
+    are delivered when circuit breaker state affects this session's profile
+    (see :meth:`SessionRegistry.broadcast_tools_changed`).  Keepalive comment
+    frames are interleaved during idle periods to hold the socket open.
     """
     profile_name = request.path_params.get("profile", "")
     profile = registry.get(profile_name)
@@ -127,28 +135,47 @@ async def _handle_get(
     if session.profile_name != profile_name:
         return _plain(403, "Session does not belong to this profile")
 
-    import asyncio
-    from collections.abc import AsyncIterator  # noqa: TC003
-
-    from starlette.responses import StreamingResponse
-
-    async def event_stream() -> AsyncIterator[str]:
-        yield f"event: endpoint\ndata: /gateway/{profile_name}/mcp\n\n"
-        try:
-            while True:
-                await asyncio.sleep(30)
-                yield ": keepalive\n\n"
-        except asyncio.CancelledError:
-            return
-
     return StreamingResponse(
-        event_stream(),
+        _sse_event_stream(sessions, session_id),
         media_type="text/event-stream",
         headers={
             MCP_SESSION_ID_HEADER: session_id,
             "Cache-Control": "no-cache",
         },
     )
+
+
+async def _sse_event_stream(
+    sessions: SessionRegistry,
+    session_id: str,
+    keepalive_seconds: float = SSE_KEEPALIVE_SECONDS,
+) -> AsyncIterator[str]:
+    """Yield SSE frames for one server-push stream.
+
+    Subscribes a notification queue for ``session_id`` and drains it as
+    MCP-compliant ``event: message`` frames.  When no notification arrives
+    within ``keepalive_seconds``, emits a comment keepalive instead.  Always
+    deregisters the queue on disconnect (``CancelledError``) or exit.
+
+    The ``retry:`` reconnect hint is emitted before any data so it is set
+    even if the client reconnects immediately.
+    """
+    queue = sessions.subscribe(session_id)
+    try:
+        yield f"retry: {SSE_RETRY_MS}\n\n"
+        while True:
+            try:
+                notification = await asyncio.wait_for(
+                    queue.get(), timeout=keepalive_seconds
+                )
+            except asyncio.TimeoutError:
+                yield ": keepalive\n\n"
+                continue
+            yield f"event: message\ndata: {json.dumps(notification)}\n\n"
+    except asyncio.CancelledError:
+        return
+    finally:
+        sessions.unsubscribe(session_id, queue)
 
 
 async def _handle_delete(

--- a/src/mcp_trentina_crunchtools/gateway/sessions.py
+++ b/src/mcp_trentina_crunchtools/gateway/sessions.py
@@ -13,6 +13,7 @@ affects a profile's tool list.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 import uuid
@@ -23,6 +24,11 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_SESSION_TTL = 300.0
 DEFAULT_MAX_SESSIONS_PER_PROFILE = 10
+
+SUBSCRIBER_QUEUE_MAXSIZE = 32
+"""Bound per subscriber queue so a stalled SSE reader can't grow memory
+without limit. listChanged is idempotent, so dropping a frame on a full
+queue is harmless — the client re-requests tools/list on the next one."""
 
 
 @dataclass
@@ -44,14 +50,47 @@ class SessionRegistry:
     _sessions: dict[str, Session] = field(default_factory=dict)
     _profile_index: dict[str, set[str]] = field(default_factory=dict)
     _notification_callback: Any = field(default=None)
+    _subscribers: dict[str, set[asyncio.Queue[dict[str, Any]]]] = field(
+        default_factory=dict
+    )
 
     def set_notification_callback(self, callback: Any) -> None:
         """Register a callback for pushing notifications to transport sessions.
 
-        The callback signature is:
+        Optional escape hatch for transports other than the built-in SSE GET
+        stream (which delivers via :meth:`subscribe` queues).  When set, the
+        callback is invoked in addition to any subscriber queues.  Signature:
             async def callback(session_id: str, notification: dict) -> None
         """
         self._notification_callback = callback
+
+    def subscribe(self, session_id: str) -> asyncio.Queue[dict[str, Any]]:
+        """Register an SSE stream's notification queue for a session.
+
+        Returns a fresh bounded queue that :meth:`broadcast_tools_changed`
+        pushes onto.  The GET SSE handler drains it and must call
+        :meth:`unsubscribe` when the stream closes.
+        """
+        queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(
+            maxsize=SUBSCRIBER_QUEUE_MAXSIZE
+        )
+        self._subscribers.setdefault(session_id, set()).add(queue)
+        return queue
+
+    def unsubscribe(
+        self, session_id: str, queue: asyncio.Queue[dict[str, Any]]
+    ) -> None:
+        """Deregister an SSE stream's queue (call on stream close/disconnect)."""
+        subs = self._subscribers.get(session_id)
+        if subs is None:
+            return
+        subs.discard(queue)
+        if not subs:
+            del self._subscribers[session_id]
+
+    def subscriber_count(self, session_id: str) -> int:
+        """Number of live SSE streams subscribed to a session (diagnostics/tests)."""
+        return len(self._subscribers.get(session_id, ()))
 
     def create_session(self, profile_name: str) -> str:
         """Create a new session for a profile.  Returns the session ID.
@@ -132,31 +171,49 @@ class SessionRegistry:
     async def broadcast_tools_changed(self, profile_name: str) -> int:
         """Push ``notifications/tools/listChanged`` to all sessions for a profile.
 
-        Returns the number of sessions notified.
+        Delivers to each session's live SSE subscriber queues (the built-in
+        transport) and, when set, to :attr:`_notification_callback`.  Returns
+        the number of sessions that received at least one delivery.
         """
         sessions = self.get_sessions_for_profile(profile_name)
         if not sessions:
             return 0
 
-        notification = {
+        notification: dict[str, Any] = {
             "jsonrpc": "2.0",
             "method": "notifications/tools/listChanged",
         }
 
         notified = 0
         for session in sessions:
+            delivered = False
+
             if self._notification_callback is not None:
                 try:
                     await self._notification_callback(
                         session.session_id, notification
                     )
-                    notified += 1
+                    delivered = True
                 except Exception:
                     logger.warning(
                         "sessions: failed to notify session=%s",
                         session.session_id[:8],
                         exc_info=True,
                     )
+
+            for queue in list(self._subscribers.get(session.session_id, ())):
+                try:
+                    queue.put_nowait(dict(notification))
+                    delivered = True
+                except asyncio.QueueFull:
+                    logger.warning(
+                        "sessions: subscriber queue full, dropped "
+                        "listChanged for session=%s",
+                        session.session_id[:8],
+                    )
+
+            if delivered:
+                notified += 1
         if notified:
             logger.info(
                 "sessions: broadcast tools/listChanged to %d session(s) "
@@ -176,9 +233,11 @@ class SessionRegistry:
         """Clear all sessions (for testing)."""
         self._sessions.clear()
         self._profile_index.clear()
+        self._subscribers.clear()
 
     def _remove(self, session_id: str) -> bool:
         session = self._sessions.pop(session_id, None)
+        self._subscribers.pop(session_id, None)
         if session is None:
             return False
         profile_set = self._profile_index.get(session.profile_name)

--- a/tests/test_gateway_sessions.py
+++ b/tests/test_gateway_sessions.py
@@ -183,3 +183,84 @@ class TestBroadcast:
 
         count = await registry.broadcast_tools_changed("alice")
         assert count == 1
+
+
+class TestSubscribers:
+    @pytest.mark.asyncio
+    async def test_broadcast_delivers_to_subscriber_queue(self) -> None:
+        registry = SessionRegistry(session_ttl=300.0, max_sessions_per_profile=10)
+        sid = registry.create_session("alice")
+        queue = registry.subscribe(sid)
+
+        count = await registry.broadcast_tools_changed("alice")
+        assert count == 1
+
+        notification = queue.get_nowait()
+        assert notification["method"] == "notifications/tools/listChanged"
+        assert notification["jsonrpc"] == "2.0"
+
+    @pytest.mark.asyncio
+    async def test_broadcast_delivers_to_all_subscribers_of_session(self) -> None:
+        registry = SessionRegistry(session_ttl=300.0, max_sessions_per_profile=10)
+        sid = registry.create_session("alice")
+        q1 = registry.subscribe(sid)
+        q2 = registry.subscribe(sid)
+
+        count = await registry.broadcast_tools_changed("alice")
+        assert count == 1
+        assert q1.get_nowait()["method"] == "notifications/tools/listChanged"
+        assert q2.get_nowait()["method"] == "notifications/tools/listChanged"
+
+    @pytest.mark.asyncio
+    async def test_broadcast_only_targets_matching_profile(self) -> None:
+        registry = SessionRegistry(session_ttl=300.0, max_sessions_per_profile=10)
+        alice_sid = registry.create_session("alice")
+        bob_sid = registry.create_session("bob")
+        alice_q = registry.subscribe(alice_sid)
+        bob_q = registry.subscribe(bob_sid)
+
+        count = await registry.broadcast_tools_changed("alice")
+        assert count == 1
+        assert not alice_q.empty()
+        assert bob_q.empty()
+
+    @pytest.mark.asyncio
+    async def test_unsubscribe_stops_delivery(self) -> None:
+        registry = SessionRegistry(session_ttl=300.0, max_sessions_per_profile=10)
+        sid = registry.create_session("alice")
+        queue = registry.subscribe(sid)
+        assert registry.subscriber_count(sid) == 1
+
+        registry.unsubscribe(sid, queue)
+        assert registry.subscriber_count(sid) == 0
+
+        count = await registry.broadcast_tools_changed("alice")
+        assert count == 0
+        assert queue.empty()
+
+    @pytest.mark.asyncio
+    async def test_callback_and_subscriber_count_session_once(self) -> None:
+        registry = SessionRegistry(session_ttl=300.0, max_sessions_per_profile=10)
+        callback = AsyncMock()
+        registry.set_notification_callback(callback)
+        sid = registry.create_session("alice")
+        queue = registry.subscribe(sid)
+
+        count = await registry.broadcast_tools_changed("alice")
+        assert count == 1
+        assert callback.call_count == 1
+        assert not queue.empty()
+
+    def test_delete_session_drops_subscribers(self) -> None:
+        registry = SessionRegistry(session_ttl=300.0, max_sessions_per_profile=10)
+        sid = registry.create_session("alice")
+        registry.subscribe(sid)
+        registry.delete_session(sid)
+        assert registry.subscriber_count(sid) == 0
+
+    def test_reset_clears_subscribers(self) -> None:
+        registry = SessionRegistry(session_ttl=300.0, max_sessions_per_profile=10)
+        sid = registry.create_session("alice")
+        registry.subscribe(sid)
+        registry.reset()
+        assert registry.subscriber_count(sid) == 0

--- a/tests/test_gateway_streamable.py
+++ b/tests/test_gateway_streamable.py
@@ -2,12 +2,21 @@
 
 from __future__ import annotations
 
+import asyncio
+import json
 from unittest.mock import patch
 
+import pytest
 from pydantic import SecretStr
 from starlette.testclient import TestClient
 
-from mcp_trentina_crunchtools.gateway.app import MCP_SESSION_ID_HEADER, gateway_app
+from mcp_trentina_crunchtools import _wire_circuit_notifications
+from mcp_trentina_crunchtools.gateway.app import (
+    MCP_SESSION_ID_HEADER,
+    SSE_RETRY_MS,
+    _sse_event_stream,
+    gateway_app,
+)
 from mcp_trentina_crunchtools.gateway.circuit import CircuitBreaker, State
 from mcp_trentina_crunchtools.gateway.profile import AuthConfig, Backend, Profile
 from mcp_trentina_crunchtools.gateway.router import NAMESPACE_SEP
@@ -258,6 +267,122 @@ class TestStreamableHTTPGet:
         session = sessions.get_session(sid)
         assert session is not None
         assert session.profile_name == "alice"
+
+
+class TestSSEEventStream:
+    """The long-lived SSE stream that carries server-push notifications."""
+
+    @pytest.mark.asyncio
+    async def test_first_frame_is_retry_hint(self) -> None:
+        sessions = SessionRegistry(session_ttl=300.0, max_sessions_per_profile=10)
+        sid = sessions.create_session("alice")
+        stream = _sse_event_stream(sessions, sid, keepalive_seconds=5.0)
+        try:
+            first = await stream.__anext__()
+            assert first == f"retry: {SSE_RETRY_MS}\n\n"
+        finally:
+            await stream.aclose()
+
+    @pytest.mark.asyncio
+    async def test_stream_subscribes_on_open(self) -> None:
+        sessions = SessionRegistry(session_ttl=300.0, max_sessions_per_profile=10)
+        sid = sessions.create_session("alice")
+        stream = _sse_event_stream(sessions, sid, keepalive_seconds=5.0)
+        try:
+            await stream.__anext__()  # retry frame; subscription is now live
+            assert sessions.subscriber_count(sid) == 1
+        finally:
+            await stream.aclose()
+
+    @pytest.mark.asyncio
+    async def test_broadcast_delivers_message_frame(self) -> None:
+        sessions = SessionRegistry(session_ttl=300.0, max_sessions_per_profile=10)
+        sid = sessions.create_session("alice")
+        stream = _sse_event_stream(sessions, sid, keepalive_seconds=5.0)
+        try:
+            await stream.__anext__()  # drain retry frame, register subscription
+
+            count = await sessions.broadcast_tools_changed("alice")
+            assert count == 1
+
+            frame = await stream.__anext__()
+            assert frame.startswith("event: message\ndata: ")
+            payload = json.loads(frame.split("data: ", 1)[1].strip())
+            assert payload["method"] == "notifications/tools/listChanged"
+            assert "event: endpoint" not in frame
+        finally:
+            await stream.aclose()
+
+    @pytest.mark.asyncio
+    async def test_keepalive_on_idle(self) -> None:
+        sessions = SessionRegistry(session_ttl=300.0, max_sessions_per_profile=10)
+        sid = sessions.create_session("alice")
+        stream = _sse_event_stream(sessions, sid, keepalive_seconds=0.01)
+        try:
+            await stream.__anext__()  # retry frame
+            frame = await stream.__anext__()  # nothing queued → keepalive
+            assert frame == ": keepalive\n\n"
+        finally:
+            await stream.aclose()
+
+    @pytest.mark.asyncio
+    async def test_close_unsubscribes(self) -> None:
+        sessions = SessionRegistry(session_ttl=300.0, max_sessions_per_profile=10)
+        sid = sessions.create_session("alice")
+        stream = _sse_event_stream(sessions, sid, keepalive_seconds=5.0)
+        await stream.__anext__()
+        assert sessions.subscriber_count(sid) == 1
+        await stream.aclose()
+        assert sessions.subscriber_count(sid) == 0
+
+
+class TestCircuitToSSEDelivery:
+    """End-to-end: a circuit trip reaches a subscribed session's queue."""
+
+    @pytest.mark.asyncio
+    async def test_circuit_open_delivers_listchanged(self) -> None:
+        backend_url = "http://mcp-slack:8005/mcp"
+        profile = _make_profile()
+        profiles = {"alice": profile}
+        sessions = SessionRegistry(session_ttl=300.0, max_sessions_per_profile=10)
+        cb = CircuitBreaker(failure_threshold=2, cooldown_seconds=0.01)
+
+        _wire_circuit_notifications(cb, sessions, profiles)
+
+        sid = sessions.create_session("alice")
+        queue = sessions.subscribe(sid)
+
+        cb.record_failure(backend_url)
+        cb.record_failure(backend_url)
+
+        for _ in range(50):
+            if not queue.empty():
+                break
+            await asyncio.sleep(0.01)
+
+        assert not queue.empty()
+        notification = queue.get_nowait()
+        assert notification["method"] == "notifications/tools/listChanged"
+
+    @pytest.mark.asyncio
+    async def test_unaffected_profile_not_notified(self) -> None:
+        profile = _make_profile()  # backend http://mcp-slack:8005/mcp
+        profiles = {"alice": profile}
+        sessions = SessionRegistry(session_ttl=300.0, max_sessions_per_profile=10)
+        cb = CircuitBreaker(failure_threshold=2, cooldown_seconds=0.01)
+
+        _wire_circuit_notifications(cb, sessions, profiles)
+
+        sid = sessions.create_session("alice")
+        queue = sessions.subscribe(sid)
+
+        cb.record_failure("http://other:9000/mcp")
+        cb.record_failure("http://other:9000/mcp")
+
+        for _ in range(10):
+            await asyncio.sleep(0.01)
+
+        assert queue.empty()
 
 
 class TestBackwardsCompatibility:


### PR DESCRIPTION
## Summary

Closes #44. The gateway already *computed* `tools/listChanged` notifications when a backend's circuit breaker opened or closed, but never **delivered** them — `set_notification_callback` had zero callers, so `broadcast_tools_changed` looped the sessions and dropped every frame, and the GET SSE handler was a stub emitting only keepalives. Agents held a stale tool list after a backend went down or recovered.

This wires the delivery path end to end:

- **`sessions.py`** — per-session subscriber-queue model (`subscribe` / `unsubscribe` / `subscriber_count`) with bounded queues. `broadcast_tools_changed` pushes onto every live SSE queue for the session (a full queue drops harmlessly — `listChanged` is idempotent) and still honors the optional `_notification_callback` escape hatch. `_remove`/`reset` drop subscribers so teardown and TTL expiry don't leak.
- **`app.py`** — replaced the GET SSE stub with a module-level `_sse_event_stream` generator: subscribes on open, drains notifications as MCP-compliant `event: message` frames, interleaves keepalives on idle, and always unsubscribes on disconnect. Drops the legacy `event: endpoint` frame and adds a `retry:` reconnect hint on open.

The pre-existing `_wire_circuit_notifications` startup path now delivers for free — no new wiring at startup.

### Bonus: partially closes #51
The GET rewrite inherently lands #51 items **1** (`retry:` reconnect hint) and **3** (`event: message` framing, killing the "Unknown SSE event: endpoint" warning). Keepalive (item 2) now lives in the real stream.

## Test plan

- [x] Registry: subscriber delivery, multi-stream fan-out, profile isolation, unsubscribe-stops-delivery, single-count semantics, teardown/reset cleanup
- [x] SSE stream: retry-first framing, subscribe-on-open, `event: message` delivery, keepalive-on-idle, unsubscribe-on-close
- [x] End-to-end: real circuit trip (`CLOSED→OPEN`) reaches a subscribed session's queue; unaffected profile stays silent
- [x] Full suite: 665 passed, 54 skipped; `ruff` + `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)