### PR TITLE
ci: Gatehouse review advisory by default (v0.4.0)

### DIFF
--- a/.github/workflows/gatehouse.yml
+++ b/.github/workflows/gatehouse.yml
@@ -10,8 +10,14 @@
 # rules (your styleguide/constitution) are fetched from YOUR base branch, not the
 # PR. The one thing you don't trust — the proposed change — is only ever read.
 #
-# Two jobs, two independent required checks. Mark both required in branch
-# protection so either failing blocks the merge.
+# Two jobs with DIFFERENT authority:
+#   • guard   — a real blocking gate. Mark it a REQUIRED status check so a PR
+#               that tampers with your workflow files is rejected.
+#   • review  — ADVISORY. It posts findings as PR comments and always passes;
+#               do NOT mark it required. An LLM reviewer is non-deterministic,
+#               so it must never hold merge authority. (Opt into blocking with
+#               `blocking: true` on the review job only if you accept that
+#               tradeoff — and even then, keep it out of branch protection.)
 
 name: Gatehouse
 
@@ -66,6 +72,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: crunchtools/gatehouse/.github/workflows/review.yml@v0.2.0
+    uses: crunchtools/gatehouse/.github/workflows/review.yml@v0.4.0
     secrets:
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}


### PR DESCRIPTION
Bumps the Gatehouse reusable review workflow to `@v0.4.0`, which is **advisory by construction** — it exits `0` regardless of findings and posts a plain `COMMENT` review instead of `REQUEST_CHANGES`.

## Why

This repo's `Gatehouse review` check was marked a **required** status check, which let a non-deterministic LLM finding block merges (see `crunchtools/gatehouse#23`). The required-check has already been removed from branch protection; this PR aligns the workflow file:

- Pins `review.yml@v0.2.0` → `@v0.4.0` (advisory default).
- Corrects the guidance that told adopters to mark the review job required — only the `Protect workflows` guard is a blocking gate (per crunchtools constitution §XII).

No secrets or job structure change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)