### PR TITLE
feat(gateway): diagnose session disconnects with lifecycle logging

### DIFF
--- a/src/mcp_trentina_crunchtools/__init__.py
+++ b/src/mcp_trentina_crunchtools/__init__.py
@@ -27,8 +27,23 @@ if TYPE_CHECKING:
     from fastmcp import FastMCP
 
 
+def _configure_logging() -> None:
+    """Send application logs to stderr at ``TRENTINA_LOG_LEVEL`` (default INFO).
+
+    Without this the root logger sits at WARNING and every ``logger.info`` in
+    the gateway — session lifecycle above all — is silently discarded, leaving
+    only uvicorn's access log to diagnose from.
+    """
+    level_name = os.environ.get("TRENTINA_LOG_LEVEL", "INFO").strip().upper()
+    logging.basicConfig(
+        level=getattr(logging, level_name, logging.INFO),
+        format="%(asctime)s %(levelname)-8s %(name)s: %(message)s",
+    )
+
+
 def main() -> None:
     """Entry point for mcp-trentina-crunchtools."""
+    _configure_logging()
     parser = argparse.ArgumentParser(
         prog="mcp-trentina-crunchtools",
         description="MCP server for quarantined web content extraction and gateway",
@@ -105,6 +120,14 @@ def _run_with_gateway(mcp_server: FastMCP, *, host: str, port: int) -> None:
 
     session_registry.session_ttl = gateway_config.session_ttl_seconds
     session_registry.max_sessions_per_profile = gateway_config.max_sessions_per_profile
+    logger.info(
+        "gateway: session_ttl=%.0fs max_sessions_per_profile=%d "
+        "(set gateway.session_ttl_seconds / gateway.max_sessions_per_profile "
+        "in %s to change)",
+        gateway_config.session_ttl_seconds,
+        gateway_config.max_sessions_per_profile,
+        profiles_path,
+    )
 
     register_internal_server(mcp_server)
     register_with_fastmcp(mcp_server, gateway_config.profiles, session_registry)

--- a/src/mcp_trentina_crunchtools/gateway/app.py
+++ b/src/mcp_trentina_crunchtools/gateway/app.py
@@ -55,6 +55,18 @@ SSE_RETRY_MS = 15000
 ``retry:`` and back off at the protocol layer, bypassing app-level retry caps."""
 
 
+def _client_desc(request: Request) -> str:
+    """Identify the caller for correlating a disconnect with one client.
+
+    Source port distinguishes concurrent clients behind the same address,
+    which is what separates one agent terminal from another over a tunnel.
+    """
+    client = request.client
+    peer = f"{client.host}:{client.port}" if client is not None else "unknown"
+    agent = request.headers.get("user-agent", "-")
+    return f"peer={peer} ua={agent!r}"
+
+
 def gateway_app(
     registry: dict[str, Profile],
     sessions: SessionRegistry | None = None,
@@ -130,11 +142,24 @@ async def _handle_get(
 
     session = sessions.get_session(session_id)
     if session is None:
+        logger.warning(
+            "gateway: SSE stream rejected — session=%s profile=%s not found: %s [%s]",
+            session_id[:8],
+            profile_name,
+            sessions.explain_missing(session_id),
+            _client_desc(request),
+        )
         return _plain(404, "Session not found or expired")
 
     if session.profile_name != profile_name:
         return _plain(403, "Session does not belong to this profile")
 
+    logger.info(
+        "gateway: SSE stream opened session=%s profile=%s [%s]",
+        session_id[:8],
+        profile_name,
+        _client_desc(request),
+    )
     return StreamingResponse(
         _sse_event_stream(sessions, session_id),
         media_type="text/event-stream",
@@ -200,6 +225,13 @@ async def _handle_delete(
 
     session = sessions.get_session(session_id)
     if session is None:
+        logger.warning(
+            "gateway: DELETE rejected — session=%s profile=%s not found: %s [%s]",
+            session_id[:8],
+            profile_name,
+            sessions.explain_missing(session_id),
+            _client_desc(request),
+        )
         return _plain(404, "Session not found or expired")
 
     if session.profile_name != profile_name:
@@ -254,6 +286,16 @@ async def _handle_post(
     if session_id:
         session = sessions.get_session(session_id)
         if session is None:
+            logger.warning(
+                "gateway: DISCONNECT — session=%s profile=%s rejected on "
+                "method=%r: %s [%s] census=%s",
+                session_id[:8],
+                profile_name,
+                body.get("method", ""),
+                sessions.explain_missing(session_id),
+                _client_desc(request),
+                sessions.census(),
+            )
             return _plain(404, "Session not found or expired")
         if session.profile_name != profile_name:
             return _plain(403, "Session does not belong to this profile")
@@ -305,6 +347,12 @@ async def _handle_post(
     if method == "initialize":
         new_session_id = sessions.create_session(profile_name)
         headers[MCP_SESSION_ID_HEADER] = new_session_id
+        logger.info(
+            "gateway: initialize session=%s profile=%s [%s]",
+            new_session_id[:8],
+            profile_name,
+            _client_desc(request),
+        )
     elif session_id:
         headers[MCP_SESSION_ID_HEADER] = session_id
 

--- a/src/mcp_trentina_crunchtools/gateway/sessions.py
+++ b/src/mcp_trentina_crunchtools/gateway/sessions.py
@@ -30,6 +30,17 @@ SUBSCRIBER_QUEUE_MAXSIZE = 32
 without limit. listChanged is idempotent, so dropping a frame on a full
 queue is harmless — the client re-requests tools/list on the next one."""
 
+REASON_TTL_EXPIRED = "ttl_expired"
+REASON_EVICTED = "evicted_max_sessions"
+REASON_CLIENT_DELETE = "client_delete"
+REASON_REGISTRY_RESET = "registry_reset"
+
+TOMBSTONE_MAXSIZE = 512
+"""How many ended sessions to remember so a later 404 can name its cause.
+Without this a stale-session 404 is indistinguishable from a bad token or a
+gateway restart, which is exactly the ambiguity that makes disconnects hard
+to diagnose."""
+
 
 @dataclass
 class Session:
@@ -39,6 +50,18 @@ class Session:
     profile_name: str
     created_at: float
     last_access: float
+
+
+@dataclass
+class Tombstone:
+    """Why a session stopped existing, kept for post-mortem on the next 404."""
+
+    session_id: str
+    profile_name: str
+    reason: str
+    ended_at: float
+    lifetime_seconds: float
+    idle_seconds: float
 
 
 @dataclass
@@ -53,6 +76,7 @@ class SessionRegistry:
     _subscribers: dict[str, set[asyncio.Queue[dict[str, Any]]]] = field(
         default_factory=dict
     )
+    _tombstones: dict[str, Tombstone] = field(default_factory=dict)
 
     def set_notification_callback(self, callback: Any) -> None:
         """Register a callback for pushing notifications to transport sessions.
@@ -111,12 +135,17 @@ class SessionRegistry:
                     oldest_id = sid
             if oldest_id is None:
                 break
-            self._remove(oldest_id)
+            evicted_idle = time.monotonic() - oldest_time
+            self._remove(oldest_id, REASON_EVICTED)
             profile_sessions = self._profile_index.get(profile_name, set())
-            logger.info(
-                "sessions: evicted oldest session for profile=%s (limit=%d)",
+            logger.warning(
+                "sessions: EVICTED session=%s profile=%s — at max_sessions_per_profile"
+                "=%d; victim was idle %.1fs. Raise gateway.max_sessions_per_profile "
+                "in profiles.yaml if this is disconnecting live clients.",
+                oldest_id[:8],
                 profile_name,
                 self.max_sessions_per_profile,
+                evicted_idle,
             )
 
         now = time.monotonic()
@@ -131,12 +160,42 @@ class SessionRegistry:
         self._profile_index.setdefault(profile_name, set()).add(session_id)
 
         logger.info(
-            "sessions: created session=%s profile=%s (active=%d)",
+            "sessions: created session=%s profile=%s (active=%d/%d, ttl=%.0fs) "
+            "census=%s",
             session_id[:8],
             profile_name,
             len(self._profile_index.get(profile_name, set())),
+            self.max_sessions_per_profile,
+            self.session_ttl,
+            self.census(),
         )
         return session_id
+
+    def census(self) -> dict[str, int]:
+        """Live session count per profile, for tracking accumulation over time."""
+        return {
+            pname: len(ids) for pname, ids in self._profile_index.items() if ids
+        }
+
+    def explain_missing(self, session_id: str) -> str:
+        """Describe why ``session_id`` is not in the registry.
+
+        Turns an otherwise opaque 404 into a cause: TTL expiry, eviction under
+        the per-profile cap, an explicit client teardown, or a session this
+        process never issued at all (typically a client that outlived a
+        gateway restart).
+        """
+        tomb = self._tombstones.get(session_id)
+        if tomb is None:
+            return (
+                "never issued by this gateway process — client predates a "
+                "gateway restart, or is using a session from another process"
+            )
+        return (
+            f"{tomb.reason} {time.monotonic() - tomb.ended_at:.1f}s ago "
+            f"(profile={tomb.profile_name}, lived {tomb.lifetime_seconds:.1f}s, "
+            f"idle {tomb.idle_seconds:.1f}s when it ended)"
+        )
 
     def get_session(self, session_id: str) -> Session | None:
         """Look up a session by ID, returning None if expired or unknown."""
@@ -148,7 +207,7 @@ class SessionRegistry:
 
     def delete_session(self, session_id: str) -> bool:
         """Explicitly tear down a session.  Returns True if it existed."""
-        return self._remove(session_id)
+        return self._remove(session_id, REASON_CLIENT_DELETE)
 
     def get_sessions_for_profile(self, profile_name: str) -> list[Session]:
         """Return all active sessions for a profile."""
@@ -231,11 +290,14 @@ class SessionRegistry:
 
     def reset(self) -> None:
         """Clear all sessions (for testing)."""
+        for sid in list(self._sessions):
+            self._remove(sid, REASON_REGISTRY_RESET)
         self._sessions.clear()
         self._profile_index.clear()
         self._subscribers.clear()
+        self._tombstones.clear()
 
-    def _remove(self, session_id: str) -> bool:
+    def _remove(self, session_id: str, reason: str) -> bool:
         session = self._sessions.pop(session_id, None)
         self._subscribers.pop(session_id, None)
         if session is None:
@@ -245,18 +307,40 @@ class SessionRegistry:
             profile_set.discard(session_id)
             if not profile_set:
                 del self._profile_index[session.profile_name]
+
+        now = time.monotonic()
+        self._tombstones[session_id] = Tombstone(
+            session_id=session_id,
+            profile_name=session.profile_name,
+            reason=reason,
+            ended_at=now,
+            lifetime_seconds=now - session.created_at,
+            idle_seconds=now - session.last_access,
+        )
+        while len(self._tombstones) > TOMBSTONE_MAXSIZE:
+            self._tombstones.pop(next(iter(self._tombstones)))
         return True
 
     def _expire_stale(self) -> None:
         now = time.monotonic()
         expired = [
-            sid
+            (sid, now - s.last_access)
             for sid, s in self._sessions.items()
             if (now - s.last_access) > self.session_ttl
         ]
-        for sid in expired:
-            self._remove(sid)
-            logger.debug("sessions: expired session=%s", sid[:8])
+        for sid, idle in expired:
+            profile_name = self._sessions[sid].profile_name
+            self._remove(sid, REASON_TTL_EXPIRED)
+            logger.info(
+                "sessions: EXPIRED session=%s profile=%s — idle %.1fs > ttl %.0fs. "
+                "Raise gateway.session_ttl_seconds in profiles.yaml if this is "
+                "disconnecting idle clients. census=%s",
+                sid[:8],
+                profile_name,
+                idle,
+                self.session_ttl,
+                self.census(),
+            )
 
 
 session_registry = SessionRegistry()

--- a/tests/test_gateway_sessions.py
+++ b/tests/test_gateway_sessions.py
@@ -8,6 +8,10 @@ from unittest.mock import AsyncMock
 import pytest
 
 from mcp_trentina_crunchtools.gateway.sessions import (
+    REASON_CLIENT_DELETE,
+    REASON_EVICTED,
+    REASON_TTL_EXPIRED,
+    TOMBSTONE_MAXSIZE,
     SessionRegistry,
 )
 
@@ -264,3 +268,59 @@ class TestSubscribers:
         registry.subscribe(sid)
         registry.reset()
         assert registry.subscriber_count(sid) == 0
+
+
+class TestDisconnectDiagnostics:
+    def test_expired_session_is_explained_as_ttl(self) -> None:
+        registry = SessionRegistry(session_ttl=0.01, max_sessions_per_profile=10)
+        sid = registry.create_session("alice")
+        time.sleep(0.02)
+        assert registry.get_session(sid) is None
+        assert REASON_TTL_EXPIRED in registry.explain_missing(sid)
+
+    def test_evicted_session_is_explained_as_eviction(self) -> None:
+        registry = SessionRegistry(session_ttl=300.0, max_sessions_per_profile=2)
+        first = registry.create_session("alice")
+        time.sleep(0.01)
+        registry.create_session("alice")
+        time.sleep(0.01)
+        registry.create_session("alice")
+        assert registry.get_session(first) is None
+        assert REASON_EVICTED in registry.explain_missing(first)
+
+    def test_ttl_and_eviction_are_distinguishable(self) -> None:
+        """The whole point: a 404 must name which limit killed the session."""
+        registry = SessionRegistry(session_ttl=300.0, max_sessions_per_profile=1)
+        evicted = registry.create_session("alice")
+        registry.create_session("alice")
+
+        idle = SessionRegistry(session_ttl=0.01, max_sessions_per_profile=10)
+        expired = idle.create_session("bob")
+        time.sleep(0.02)
+        idle.get_session(expired)
+
+        assert REASON_EVICTED in registry.explain_missing(evicted)
+        assert REASON_TTL_EXPIRED in idle.explain_missing(expired)
+
+    def test_client_delete_is_explained(self) -> None:
+        registry = SessionRegistry(session_ttl=300.0, max_sessions_per_profile=10)
+        sid = registry.create_session("alice")
+        registry.delete_session(sid)
+        assert REASON_CLIENT_DELETE in registry.explain_missing(sid)
+
+    def test_unknown_session_reports_never_issued(self) -> None:
+        registry = SessionRegistry(session_ttl=300.0, max_sessions_per_profile=10)
+        assert "never issued" in registry.explain_missing("deadbeef" * 4)
+
+    def test_tombstones_are_bounded(self) -> None:
+        registry = SessionRegistry(session_ttl=300.0, max_sessions_per_profile=1)
+        for _ in range(TOMBSTONE_MAXSIZE + 25):
+            registry.create_session("alice")
+        assert len(registry._tombstones) <= TOMBSTONE_MAXSIZE
+
+    def test_census_counts_live_sessions_per_profile(self) -> None:
+        registry = SessionRegistry(session_ttl=300.0, max_sessions_per_profile=10)
+        registry.create_session("alice")
+        registry.create_session("alice")
+        registry.create_session("bob")
+        assert registry.census() == {"alice": 2, "bob": 1}


### PR DESCRIPTION
## Problem

Claude terminals disconnect from the gateway at random. Diagnosing it today is guesswork:

- The gateway returns a bare `404 Session not found or expired` for **four different causes** — TTL expiry, max-sessions eviction, explicit client teardown, and a session this process never issued (client outlived a restart). They are indistinguishable in the logs.
- **The codebase has no logging configuration at all.** The root logger sits at WARNING, so every `logger.info` in the gateway — including the session registry's existing `created` / `evicted` / `expired` lines — is silently discarded. Only uvicorn's access log survives, which is why diagnosis has meant correlating bare 404s against wall-clock gaps.

## Changes

- `_configure_logging()` in the entrypoint, driven by `TRENTINA_LOG_LEVEL` (default `INFO`). This alone makes the registry's pre-existing lifecycle logs visible.
- A bounded tombstone (512) recorded for every ended session with its cause, so `explain_missing()` can name *why* a session is gone on the next 404.
- Session-rejection 404s now log the cause, client peer + user-agent, the JSON-RPC method attempted, and a per-profile session census.
- Effective `session_ttl` / `max_sessions_per_profile` logged at startup, naming the `profiles.yaml` keys that change them.

## What the output looks like

```
WARNING gateway: DISCONNECT — session=e8b331ff profile=josui rejected on method='tools/call':
  ttl_expired 12.4s ago (profile=josui, lived 481.2s, idle 312.7s when it ended)
  [peer=10.89.0.1:42484 ua='node'] census={'josui': 3}

WARNING sessions: EVICTED session=5bd63fb4 profile=josui — at max_sessions_per_profile=10;
  victim was idle 41.0s. Raise gateway.max_sessions_per_profile in profiles.yaml if this
  is disconnecting live clients.
```

The `census` field is the one that settles TTL-vs-eviction: if josui is sitting at the cap when a disconnect lands, it's eviction.

## Notes

- Behaviour is unchanged — this is diagnostics only. No TTL or cap values were altered; both are already tunable from `profiles.yaml` (`gateway.session_ttl_seconds`, `gateway.max_sessions_per_profile`) with no code change.
- `_remove()` now requires an explicit reason argument so no removal path can forget to record one.

## Verification

- 672 passed, 54 skipped (7 new tests covering each disconnect cause and the tombstone bound)
- ruff + mypy: identical to `main` (3 ruff / 2 mypy pre-existing in untouched files, zero added)
- gourmand: 13 violations on both `main` and this branch — zero added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bacDLTVsvNWk5scp1gCw6