### PR TITLE
fix: green CI and two latent gateway defects

### DIFF
--- a/gourmand-exceptions.toml
+++ b/gourmand-exceptions.toml
@@ -246,6 +246,12 @@ pattern = "_remove"
 justification = "Called from 3 sites: delete_session, create_session (eviction loop), and _expire_stale — gourmand miscounted because create_session calls it inside a while loop"
 
 [[exceptions]]
+check = "single_use_helpers"
+path = "tests/test_gateway_router.py"
+pattern = "_profile"
+justification = "Called from 19 sites across the module — gourmand miscounts when the helper is also called from the last class in the file (same class of miscount as the sessions.py _remove exception)"
+
+[[exceptions]]
 check = "redundant_error_handling"
 path = "src/mcp_trentina_crunchtools/gateway/circuit.py"
 pattern = "_notify"

--- a/src/mcp_trentina_crunchtools/gateway/app.py
+++ b/src/mcp_trentina_crunchtools/gateway/app.py
@@ -182,6 +182,10 @@ async def _sse_event_stream(
     within ``keepalive_seconds``, emits a comment keepalive instead.  Always
     deregisters the queue on disconnect (``CancelledError``) or exit.
 
+    Each keepalive tick doubles as a liveness check: once the session is gone
+    the stream closes rather than sending keepalives forever to a session the
+    registry has already dropped.
+
     The ``retry:`` reconnect hint is emitted before any data so it is set
     even if the client reconnects immediately.
     """
@@ -194,6 +198,8 @@ async def _sse_event_stream(
                     queue.get(), timeout=keepalive_seconds
                 )
             except asyncio.TimeoutError:
+                if not sessions.is_active(session_id):
+                    return
                 yield ": keepalive\n\n"
                 continue
             yield f"event: message\ndata: {json.dumps(notification)}\n\n"

--- a/src/mcp_trentina_crunchtools/gateway/context.py
+++ b/src/mcp_trentina_crunchtools/gateway/context.py
@@ -8,10 +8,13 @@ tool calls without changing the MCP protocol or tool signatures.
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from contextvars import ContextVar
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from .profile import Profile
 
 _current_profile: ContextVar[Profile | None] = ContextVar(
@@ -19,12 +22,19 @@ _current_profile: ContextVar[Profile | None] = ContextVar(
 )
 
 
-def set_current_profile(profile: Profile) -> None:
-    """Set the profile for the current async context.
+@contextmanager
+def profile_context(profile: Profile) -> Iterator[None]:
+    """Bind ``profile`` to the current async context for the duration of the block.
 
-    Called by the gateway before dispatching to internal:// tools.
+    Used by the gateway around internal:// tool dispatch. Restoring the
+    previous value on exit is what keeps a profile from leaking into a
+    reused async task, including when the tool call raises.
     """
-    _current_profile.set(profile)
+    token = _current_profile.set(profile)
+    try:
+        yield
+    finally:
+        _current_profile.reset(token)
 
 
 def get_current_profile() -> Profile | None:

--- a/src/mcp_trentina_crunchtools/gateway/loader.py
+++ b/src/mcp_trentina_crunchtools/gateway/loader.py
@@ -61,6 +61,11 @@ def _build_profile(name: str, body: Any) -> Profile:
 
     Resolves the bearer token from `auth.bearer_token_env` and expands any
     ${VAR} references in backend headers. Both fail closed on a missing env var.
+
+    Each `llm_keys` entry supplies its secret one of two ways: `api_key`
+    inline in the YAML, or `api_key_env` naming an environment variable.
+    An inline key is taken as-is; otherwise the env var is required and an
+    entry providing neither is a configuration error.
     """
     if not isinstance(body, dict):
         raise ProfileConfigError(
@@ -78,9 +83,7 @@ def _build_profile(name: str, body: Any) -> Profile:
     profile.auth.bearer_token = SecretStr(token_value)
 
     for provider_name, override in profile.llm_keys.items():
-        # Support EITHER api_key (direct) OR api_key_env (env var reference)
         if override.api_key.get_secret_value():
-            # Direct key already present in YAML
             continue
         if not override.api_key_env:
             raise ProfileConfigError(

--- a/src/mcp_trentina_crunchtools/gateway/router.py
+++ b/src/mcp_trentina_crunchtools/gateway/router.py
@@ -252,13 +252,10 @@ async def _route_tools_call(
     t0 = time.monotonic()
     try:
         if backend.is_internal:
-            # Set profile context so internal tools can access per-profile API keys
-            from .context import _current_profile
-            token = _current_profile.set(profile)
-            try:
+            from .context import profile_context
+
+            with profile_context(profile):
                 call_result = await call_internal_tool(tool_name, arguments)
-            finally:
-                _current_profile.reset(token)
         else:
             call_result = await call_backend_tool(
                 backend_name, backend, tool_name, arguments

--- a/src/mcp_trentina_crunchtools/gateway/sessions.py
+++ b/src/mcp_trentina_crunchtools/gateway/sessions.py
@@ -205,6 +205,16 @@ class SessionRegistry:
             session.last_access = time.monotonic()
         return session
 
+    def is_active(self, session_id: str) -> bool:
+        """Whether a session is still registered, WITHOUT refreshing it.
+
+        Deliberately bypasses :meth:`get_session`: a periodic liveness poll
+        from an idle SSE stream must not keep the session alive forever,
+        which is exactly what bumping ``last_access`` would do.
+        """
+        self._expire_stale()
+        return session_id in self._sessions
+
     def delete_session(self, session_id: str) -> bool:
         """Explicitly tear down a session.  Returns True if it existed."""
         return self._remove(session_id, REASON_CLIENT_DELETE)

--- a/src/mcp_trentina_crunchtools/quarantine/agent.py
+++ b/src/mcp_trentina_crunchtools/quarantine/agent.py
@@ -13,10 +13,9 @@ from __future__ import annotations
 import json
 import logging
 import secrets
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import httpx
-from pydantic import SecretStr
 
 from ..config import get_config
 from ..errors import QuarantineAgentError
@@ -30,11 +29,17 @@ from .prompts import (
 )
 from .providers import get_provider
 
+if TYPE_CHECKING:
+    from pydantic import SecretStr
+
+    from ..gateway.profile import Profile
+
 try:
     from ..gateway.context import get_current_profile
 except ImportError:
-    # Standalone mode (no gateway)
-    def get_current_profile():
+
+    def get_current_profile() -> Profile | None:
+        """Standalone mode: no gateway, so there is never a profile context."""
         return None
 
 logger = logging.getLogger(__name__)
@@ -128,6 +133,12 @@ async def _call_gemini(
     or Ollama). Canary injection, quarantine enforcement, and response
     parsing stay here — the provider only handles the HTTP call.
 
+    Under gateway mode (a profile is bound to the current context) a
+    per-profile API key is mandatory and its absence is a hard error, so one
+    profile can never silently bill against another's key. Ollama is the sole
+    exception — it is keyless, so the requirement does not apply. Without a
+    profile the global config supplies both key and model.
+
     Args:
         provider_name: LLM provider override (default: global config or profile override).
     """
@@ -138,16 +149,13 @@ async def _call_gemini(
     if user_prompt:
         user_text = f"{user_prompt}\n\n---\n\n{content}"
 
-    # Check for profile context (gateway mode with per-profile keys)
     profile = get_current_profile()
     api_key: SecretStr | None = None
     model: str | None = None
 
     if profile is not None:
-        # Gateway mode: REQUIRE per-profile API key for key-based providers only
         resolved_provider = provider_name or profile.defense.provider or get_config().provider
 
-        # Ollama doesn't use API keys, skip the key check
         if resolved_provider == "ollama":
             api_key = None
         else:
@@ -173,7 +181,6 @@ async def _call_gemini(
             model=model,
         )
     else:
-        # Standalone mode — use global config
         provider = get_provider(provider_name)
     provider_result = await provider.generate(
         system_prompt=prompted,

--- a/src/mcp_trentina_crunchtools/quarantine/providers/__init__.py
+++ b/src/mcp_trentina_crunchtools/quarantine/providers/__init__.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import logging
-
-from pydantic import SecretStr
+from typing import TYPE_CHECKING
 
 from ...config import get_config
 from ...errors import QuarantineAgentError
 from .base import Provider, ProviderResult
+
+if TYPE_CHECKING:
+    from pydantic import SecretStr
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +28,9 @@ def get_provider(
 ) -> Provider:
     """Return a provider instance, cached per (provider, api_key, model) tuple.
 
+    The cache key uses the full secret value rather than a prefix so two
+    profiles whose keys share a prefix cannot collide onto one instance.
+
     Args:
         provider_name: Explicit provider to use. When None, falls back
             to TRENTINA_MODEL_PROVIDER from config (the global default).
@@ -38,7 +43,6 @@ def get_provider(
     resolved_provider = provider_name or config.provider
     resolved_model = model or config.model
 
-    # Build cache key from resolved values (use full key value for uniqueness)
     key_value = api_key.get_secret_value() if api_key else "global"
     cache_key = (resolved_provider, key_value, resolved_model)
 
@@ -94,9 +98,13 @@ def get_provider(
         case "ollama":
             from .ollama import OllamaProvider
 
-            # Ollama doesn't use API keys
+            default_model = (
+                resolved_model
+                if resolved_model != _DEFAULT_GEMINI_MODEL
+                else config.ollama_model
+            )
             provider = OllamaProvider(
-                model=resolved_model if resolved_model != _DEFAULT_GEMINI_MODEL else config.ollama_model,
+                model=default_model,
                 base_url=config.ollama_base_url,
             )
 

--- a/tests/test_gateway_router.py
+++ b/tests/test_gateway_router.py
@@ -13,6 +13,10 @@ from pydantic import SecretStr
 from mcp_trentina_crunchtools.database import get_gateway_call_stats
 from mcp_trentina_crunchtools.gateway.backend import BackendCall
 from mcp_trentina_crunchtools.gateway.circuit import breaker
+from mcp_trentina_crunchtools.gateway.context import (
+    get_current_profile,
+    profile_context,
+)
 from mcp_trentina_crunchtools.gateway.errors import BackendCallError, BackendNotInProfileError
 from mcp_trentina_crunchtools.gateway.profile import (
     AuthConfig,
@@ -602,3 +606,64 @@ class TestProfileToolsCache:
 
         assert "testp" in _profile_tools_cache
         assert "other" in _profile_tools_cache
+
+
+class TestProfileContext:
+    """Covers the ContextVar reset shipped untested in 4d44916."""
+
+    def test_profile_visible_inside_block(self) -> None:
+        profile = _mixed_profile()
+        assert get_current_profile() is None
+        with profile_context(profile):
+            assert get_current_profile() is profile
+        assert get_current_profile() is None
+
+    def test_profile_reset_when_body_raises(self) -> None:
+        """A failing internal tool call must not leak its profile."""
+        profile = _mixed_profile()
+        with pytest.raises(RuntimeError), profile_context(profile):
+            raise RuntimeError("tool blew up")
+        assert get_current_profile() is None
+
+    def test_nested_contexts_restore_outer(self) -> None:
+        outer = _mixed_profile()
+        inner = _profile()
+        with profile_context(outer):
+            with profile_context(inner):
+                assert get_current_profile() is inner
+            assert get_current_profile() is outer
+        assert get_current_profile() is None
+
+    async def test_internal_dispatch_resets_profile_after_call(self) -> None:
+        """End-to-end: routing an internal:// call leaves no residual context."""
+        seen: dict[str, Any] = {}
+
+        async def fake_internal_call(
+            _tool_name: str, _arguments: dict[str, Any]
+        ) -> BackendCall:
+            seen["profile_during_call"] = get_current_profile()
+            return BackendCall(
+                content=[{"type": "text", "text": "ok"}],
+                is_error=False,
+                structured_content=None,
+            )
+
+        with patch(
+            "mcp_trentina_crunchtools.gateway.router.call_internal_tool",
+            side_effect=fake_internal_call,
+        ):
+            await route_jsonrpc(
+                _mixed_profile(),
+                {
+                    "jsonrpc": "2.0",
+                    "id": 11,
+                    "method": "tools/call",
+                    "params": {
+                        "name": f"web{NAMESPACE_SEP}safe_fetch_tool",
+                        "arguments": {},
+                    },
+                },
+            )
+
+        assert seen["profile_during_call"] is not None
+        assert get_current_profile() is None

--- a/tests/test_gateway_streamable.py
+++ b/tests/test_gateway_streamable.py
@@ -326,6 +326,59 @@ class TestSSEEventStream:
             await stream.aclose()
 
     @pytest.mark.asyncio
+    async def test_stream_closes_when_session_removed(self) -> None:
+        """An orphaned stream must terminate, not keepalive into the void."""
+        sessions = SessionRegistry(session_ttl=300.0, max_sessions_per_profile=10)
+        sid = sessions.create_session("alice")
+        stream = _sse_event_stream(sessions, sid, keepalive_seconds=0.01)
+        try:
+            await stream.__anext__()  # retry frame
+            assert await stream.__anext__() == ": keepalive\n\n"
+
+            sessions.delete_session(sid)
+
+            with pytest.raises(StopAsyncIteration):
+                await stream.__anext__()
+            assert sessions.subscriber_count(sid) == 0
+        finally:
+            await stream.aclose()
+
+    @pytest.mark.asyncio
+    async def test_stream_closes_when_session_expires(self) -> None:
+        """TTL expiry reaches the stream too, not just explicit teardown."""
+        sessions = SessionRegistry(session_ttl=0.02, max_sessions_per_profile=10)
+        sid = sessions.create_session("alice")
+        stream = _sse_event_stream(sessions, sid, keepalive_seconds=0.05)
+        try:
+            await stream.__anext__()  # retry frame
+            with pytest.raises(StopAsyncIteration):
+                await stream.__anext__()
+        finally:
+            await stream.aclose()
+
+    @pytest.mark.asyncio
+    async def test_keepalive_does_not_extend_session_lifetime(self) -> None:
+        """The liveness poll must not refresh last_access.
+
+        If it did, any client holding an SSE stream would become immortal and
+        TTL expiry could never fire for it.
+        """
+        sessions = SessionRegistry(session_ttl=300.0, max_sessions_per_profile=10)
+        sid = sessions.create_session("alice")
+        session = sessions.get_session(sid)
+        assert session is not None
+        before = session.last_access
+
+        stream = _sse_event_stream(sessions, sid, keepalive_seconds=0.01)
+        try:
+            await stream.__anext__()  # retry frame
+            await stream.__anext__()  # keepalive → liveness poll runs
+            await stream.__anext__()  # and again
+            assert session.last_access == before
+        finally:
+            await stream.aclose()
+
+    @pytest.mark.asyncio
     async def test_close_unsubscribes(self) -> None:
         sessions = SessionRegistry(session_ttl=300.0, max_sessions_per_profile=10)
         sid = sessions.create_session("alice")


### PR DESCRIPTION
## Why

CI has been red on `main` since PR #59 merged — 3 ruff errors, 2 mypy errors, and 13 Gourmand violations, all in the same four files. The ruff step runs *before* pytest, so the test job never reached the suite at all.

Since those four files were already being opened, this also fixes two latent defects surfaced during the session-disconnect investigation.

## Part 1 — CI green

Gourmand's thresholds here are absolute (`max 0` comment-block lines, `0%` comment ratio). That is not arbitrary: **every other file in `gateway/` has zero `#` comments** — the house style is docstrings-only, and Gourmand exempts docstrings. All 13 violations trace by `git blame` to PR #59's commits; these four files were the sole outliers.

Redundant comments deleted. Genuine constraints moved into the docstrings of the functions they describe — the either/or `api_key` rule into `_load_profile`, the per-profile-key requirement and Ollama exemption into `_call_llm`, the cache-key uniqueness rationale into `get_provider`.

The `agent.py` standalone-mode fallback fixed three things at once — comment → docstring, plus the return annotation that resolved both mypy errors.

## Part 2 — Latent defects

**Dead helper + private access.** `set_current_profile()` was never called anywhere, while `router.py` reached into the private `_current_profile` because it needed the token back for `reset()`. Replaced with a `profile_context()` context manager: the reset becomes structural instead of a hand-written `try/finally` that can be forgotten again. Commit `4d44916` added that reset with **zero tests**; this adds them.

**Orphaned SSE streams.** When `_remove()` dropped a session, its SSE generator stayed blocked on `queue.get()` emitting keepalives forever to a session the registry had already dropped. Each keepalive tick now doubles as a liveness check via a new `SessionRegistry.is_active()`.

`is_active()` deliberately does **not** go through `get_session()`. Bumping `last_access` on every keepalive would make any session holding an SSE stream immortal — leaving eviction as the only possible disconnect mechanism and silently invalidating the investigation currently running in production. There is a test asserting this specific property.

*Behavior change:* orphaned streams now close within one keepalive interval (25s). GET/SSE clients only — kagetora/openclaw. Claude Code is POST-only on josui and unaffected.

## Verification

| gate | before | after |
|---|---|---|
| ruff | 3 errors | **0** |
| mypy | 2 errors | **0** |
| Gourmand | 13 violations | **0** |
| pytest | 672 passed | **679 passed**, 54 skipped |

**Mutation-tested** — each fix was reverted in turn to confirm the new tests actually catch the bug:

- remove the SSE liveness check → both orphan tests fail
- make `is_active()` bump `last_access` → the immortality test fails
- remove the ContextVar reset → all 4 context tests fail

One Gourmand exception added: `_profile` in `tests/test_gateway_router.py` is flagged single-use despite **19 call sites** — a scope-analysis miscount reproducible by adding any call from the file's last class. Same class of bug as the existing `sessions.py::_remove` exception, and documented as such.

## Deploy

Not deployed. Part 2B changes runtime behavior for kagetora and shouldn't ride along silently, and a redeploy disconnects every terminal again. The gateway on lotor keeps running the PR #61 image so the session-disconnect logs we're watching stay uninterrupted.

Session TTL / max-sessions untouched at 300s / 10, per the decision to change no numbers and observe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bacDLTVsvNWk5scp1gCw6