### PR TITLE
feat: automatic provider fallback chain

### DIFF
--- a/.specify/specs/012-provider-fallback-chain/plan.md
+++ b/.specify/specs/012-provider-fallback-chain/plan.md
@@ -1,0 +1,141 @@
+# Implementation Plan: Automatic Provider Fallback Chain
+
+> **Spec ID:** 012-provider-fallback-chain
+> **Status:** Planning
+> **Last Updated:** 2026-07-22
+
+## Summary
+
+Add a `provider_fallback` config field, a `_call_with_fallback()` wrapper in `agent.py`, and a `get_fallback_providers()` helper in `providers/__init__.py`. The wrapper iterates the chain on retryable errors; non-retryable errors short-circuit. `search_grounded()` is excluded.
+
+---
+
+## Architecture
+
+### Fallback Flow
+
+```
+_call_gemini() called with provider_name=None (primary)
+    │
+    ▼
+_call_with_fallback([primary] + fallback_chain)
+    │
+    ├─ attempt provider[0] (primary)
+    │   ├─ success → return result
+    │   ├─ retryable error → log warning, try provider[1]
+    │   └─ non-retryable → raise immediately
+    │
+    ├─ attempt provider[1] (first fallback)
+    │   ├─ success → return result
+    │   ├─ retryable → log warning, try provider[2]
+    │   └─ non-retryable → raise immediately
+    │
+    └─ all exhausted → raise QuarantineAgentError (caught by quarantine_extract / quarantine_detect)
+```
+
+### Data Flow
+
+1. `config.py` parses `TRENTINA_PROVIDER_FALLBACK` into `config.provider_fallback: list[str]`
+2. `get_fallback_providers()` in `providers/__init__.py` resolves each name to `(name, api_key)`, skipping providers with no key in current profile
+3. `_call_with_fallback()` in `agent.py` loops: calls `_call_gemini(provider_name=name, api_key=key)` per provider, catches retryable exceptions, moves to next
+4. `quarantine_extract()` and `quarantine_detect()` catch the final `QuarantineAgentError` as before
+
+---
+
+## Implementation Steps
+
+### Phase 1: Config
+
+- [ ] Add `provider_fallback: list[str]` to `Config.__init__()` — parse `TRENTINA_PROVIDER_FALLBACK` env var as comma-split, strip whitespace, validate each against `SUPPORTED_PROVIDERS`, raise `ConfigError` on unknown names
+- [ ] Add `DEFAULT_PROVIDER_FALLBACK: list[str] = []` constant
+
+### Phase 2: Provider Helper
+
+- [ ] Add `get_fallback_providers(profile=None)` to `quarantine/providers/__init__.py`
+  - Reads `config.provider_fallback`
+  - For each provider name, resolves the API key (gateway mode: from profile; standalone: from config)
+  - Skips providers with no key (warns via logging)
+  - Returns `list[tuple[str, SecretStr | None]]` — `(provider_name, api_key_or_none)`
+
+### Phase 3: Fallback Wrapper
+
+- [ ] Add `_is_retryable(exc: Exception) -> bool` in `agent.py`
+  - Returns True for `httpx.TimeoutException`, `httpx.ConnectError`
+  - Returns True for `QuarantineAgentError` wrapping HTTP 429 or 503 (need to preserve status code in error or check message)
+  - Returns False for everything else
+
+- [ ] Add `_call_with_fallback(content, system_prompt, response_schema, user_prompt)` in `agent.py`
+  - Builds provider chain: `[(primary_name, primary_key)] + get_fallback_providers()`
+  - Loops, calling `_call_gemini(provider_name=name, api_key=key, ...)` per provider
+  - On retryable error: log `WARNING provider {name} failed ({err}), trying {next_name}`, continue
+  - On non-retryable error: re-raise immediately
+  - On exhaustion: raise `QuarantineAgentError("all providers exhausted: {names}")`
+
+- [ ] Replace direct `_call_gemini()` calls in `quarantine_extract()` and `quarantine_detect()` with `_call_with_fallback()`
+
+### Phase 4: HTTP Status Code Preservation
+
+To distinguish 429/503 from 400/401/403 in `_is_retryable()`, the provider implementations need to surface the status code. Options:
+
+**Option A (preferred):** Add `status_code: int | None = None` field to `QuarantineAgentError` and have each provider driver set it when raising. Requires modifying all four provider drivers but keeps the error hierarchy clean.
+
+**Option B:** Parse the status code from the error message string. Fragile — avoid.
+
+Use Option A. Add `status_code` to `QuarantineAgentError.__init__()` and update all four drivers (Gemini, OpenAI, Anthropic, Ollama) to pass it.
+
+### Phase 5: Tests
+
+- [ ] Create `tests/test_provider_fallback.py`
+- [ ] Mock `httpx.AsyncClient` in relevant provider tests to simulate 429, 503, timeout, connect error
+- [ ] Test all scenarios from spec Testing Requirements section
+- [ ] Add config parsing tests (valid chain, invalid provider, empty)
+
+### Phase 6: Quality Gates
+
+- [ ] `uv run ruff check src tests`
+- [ ] `uv run mypy src`
+- [ ] `uv run pytest -v`
+- [ ] `podman run --rm -v .:/repo:Z quay.io/crunchtools/gourmand:latest --full /repo`
+- [ ] `podman build -f Containerfile .`
+
+---
+
+## File Changes
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `tests/test_provider_fallback.py` | Fallback chain unit tests |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `config.py` | Add `provider_fallback` field and `DEFAULT_PROVIDER_FALLBACK` constant |
+| `errors.py` | Add `status_code: int \| None` field to `QuarantineAgentError` |
+| `quarantine/providers/__init__.py` | Add `get_fallback_providers()` helper |
+| `quarantine/providers/gemini.py` | Pass `status_code` when raising `QuarantineAgentError` |
+| `quarantine/providers/openai.py` | Pass `status_code` when raising `QuarantineAgentError` |
+| `quarantine/providers/anthropic.py` | Pass `status_code` when raising `QuarantineAgentError` |
+| `quarantine/providers/ollama.py` | Pass `status_code` when raising `QuarantineAgentError` |
+| `quarantine/agent.py` | Add `_is_retryable()`, `_call_with_fallback()`, update callers |
+
+---
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Status code not preserved in error | Med | Option A: add `status_code` field to `QuarantineAgentError`; update all drivers |
+| Fallback leaks canary from failed attempt | Low | Canary is re-generated per `_call_gemini()` call; failed-attempt canary is never validated |
+| Gateway mode: profile has partial key set | Med | `get_fallback_providers()` skips providers with no key and logs a warning |
+| Infinite retry if error classification wrong | Low | Hard cap: at most `len(chain)` iterations; non-retryable always short-circuits |
+
+---
+
+## Changelog
+
+| Date | Changes |
+|------|---------|
+| 2026-07-22 | Initial plan |

--- a/.specify/specs/012-provider-fallback-chain/spec.md
+++ b/.specify/specs/012-provider-fallback-chain/spec.md
@@ -1,0 +1,132 @@
+# Specification: Automatic Provider Fallback Chain
+
+> **Spec ID:** 012-provider-fallback-chain
+> **Status:** Draft
+> **Version:** 0.1.0
+> **Author:** Scott McCarty
+> **Date:** 2026-07-22
+
+## Overview
+
+When the configured primary LLM provider fails with a retryable error (HTTP 429, 503, network timeout, or connection error), Trentina tries the next provider in a configured fallback chain before falling back to L1-only mode. Non-retryable errors (HTTP 400 schema errors, 401/403 auth errors) short-circuit immediately — they indicate a misconfiguration that retrying won't fix. This is separate from the gateway circuit breaker (#37), which handles backend tool-list failures at the proxy layer.
+
+---
+
+## New Tools
+
+None — this is an internal resilience feature, not a new MCP tool.
+
+---
+
+## Security Considerations
+
+### Layer 1 — Token Protection
+- Fallback providers use their own API keys (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`) stored as plain strings in `Config`. No new secret handling added; existing providers already use these fields.
+- Gateway mode: per-profile API keys still take precedence over global config keys for non-Ollama providers. The fallback chain respects profile context — if a profile has no key for a fallback provider, that provider is skipped.
+
+### Layer 2 — Input Validation
+- `TRENTINA_PROVIDER_FALLBACK` is parsed as a comma-separated list and each element is validated against `SUPPORTED_PROVIDERS` at config load time. Invalid provider names raise `ConfigError` early.
+- An empty fallback list means no chain — identical to current behavior.
+
+### Layer 3 — API Hardening
+- No new endpoints. The fallback chain calls existing `provider.generate()` implementations.
+- Canary tokens are re-generated per attempt so each provider's response is independently checked. A canary leak on a failed attempt is logged but does not block the retry.
+
+### Layer 4 — Dangerous Operation Prevention
+- No file, shell, or eval access.
+- The fallback loop has a hard cap: at most `len(chain)` iterations. No unbounded retry.
+
+---
+
+## Module Changes
+
+### New Files
+
+None.
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `config.py` | Add `provider_fallback: list[str]` field parsed from `TRENTINA_PROVIDER_FALLBACK` env var |
+| `quarantine/agent.py` | Add `_call_with_fallback()` wrapper around `_call_gemini()` that iterates the chain on retryable errors |
+| `quarantine/providers/__init__.py` | Add `get_fallback_providers()` helper that resolves the chain to a list of `(provider_name, api_key)` tuples, skipping entries without a key in the current profile context |
+
+### Retryable vs Non-Retryable Errors
+
+| Error | Retryable | Reason |
+|-------|-----------|--------|
+| HTTP 429 (rate limit) | Yes | Transient capacity issue |
+| HTTP 503 (service unavailable) | Yes | Transient provider outage |
+| `httpx.TimeoutException` | Yes | Network timeout |
+| `httpx.ConnectError` | Yes | Network unreachable |
+| HTTP 400 (bad request) | No | Schema/request error — won't improve |
+| HTTP 401 (unauthorized) | No | Auth misconfiguration |
+| HTTP 403 (forbidden) | No | Auth misconfiguration |
+| `json.JSONDecodeError` | No | Malformed response — provider-specific bug |
+
+---
+
+## Configuration
+
+| Environment Variable | Default | Description |
+|---------------------|---------|-------------|
+| `TRENTINA_MODEL_PROVIDER` | `gemini` | Primary provider |
+| `TRENTINA_PROVIDER_FALLBACK` | `""` (empty = disabled) | Comma-separated fallback chain, e.g. `openai,anthropic` |
+
+Example: primary=gemini, fallback to openai then anthropic:
+```
+TRENTINA_MODEL_PROVIDER=gemini
+TRENTINA_PROVIDER_FALLBACK=openai,anthropic
+```
+
+Sequence on retryable failure: gemini → openai → anthropic → L1-only (or raise if `QUARANTINE_FALLBACK=fail`).
+
+### `search_grounded()` exclusion
+
+`search_grounded()` in `agent.py` uses Gemini directly via raw httpx with `config.api_key` and the `google_search` grounding tool. It does **not** go through the provider abstraction and will **not** participate in the fallback chain. If it fails, it raises `QuarantineAgentError` as before.
+
+---
+
+## Testing Requirements
+
+### Unit Tests (`tests/test_quarantine_agent.py` or new `tests/test_provider_fallback.py`)
+
+- [ ] Primary provider succeeds — no fallback attempted
+- [ ] Primary returns HTTP 429 → fallback provider called
+- [ ] Primary returns HTTP 503 → fallback provider called
+- [ ] Primary raises `httpx.TimeoutException` → fallback provider called
+- [ ] Primary raises `httpx.ConnectError` → fallback provider called
+- [ ] All providers in chain fail → L1-only fallback (if `QUARANTINE_FALLBACK=layer1`)
+- [ ] All providers in chain fail → raises `QuarantineAgentError` (if `QUARANTINE_FALLBACK=fail`)
+- [ ] Primary returns HTTP 400 → no fallback, immediate fail
+- [ ] Primary returns HTTP 401 → no fallback, immediate fail
+- [ ] Empty fallback chain → behaves identically to current code
+- [ ] Gateway mode: profile with no key for fallback provider skips that provider
+
+### Config Tests
+
+- [ ] `TRENTINA_PROVIDER_FALLBACK=openai,anthropic` parses to `["openai", "anthropic"]`
+- [ ] `TRENTINA_PROVIDER_FALLBACK=invalid` raises `ConfigError`
+- [ ] `TRENTINA_PROVIDER_FALLBACK=""` parses to `[]`
+
+---
+
+## Dependencies
+
+- Depends on: PR #40 (pluggable provider drivers) — merged 2026-06-29
+- Blocks: None
+
+---
+
+## Open Questions
+
+None — requirements are clear from issue #42.
+
+---
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 0.1.0 | 2026-07-22 | Initial draft |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,3 +96,4 @@ ignore_missing_imports = true
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+pythonpath = ["src"]

--- a/src/mcp_trentina_crunchtools/config.py
+++ b/src/mcp_trentina_crunchtools/config.py
@@ -23,6 +23,7 @@ DEFAULT_CLASSIFIER_MODEL_PATH = "/models/prompt-guard-2-86m"
 DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434"
 DEFAULT_OLLAMA_MODEL = "qwen2.5:0.5b"
 SUPPORTED_PROVIDERS = ("gemini", "openai", "anthropic", "ollama")
+DEFAULT_PROVIDER_FALLBACK: list[str] = []
 
 
 class Config:
@@ -54,6 +55,16 @@ class Config:
         self.max_content: int = int(
             os.environ.get("QUARANTINE_MAX_CONTENT", str(DEFAULT_MAX_CONTENT))
         )
+
+        fallback_raw = os.environ.get("TRENTINA_PROVIDER_FALLBACK", "")
+        fallback_list = [p.strip() for p in fallback_raw.split(",") if p.strip()]
+        for p in fallback_list:
+            if p not in SUPPORTED_PROVIDERS:
+                from .errors import ConfigError
+                raise ConfigError(
+                    f"Unknown fallback provider {p!r}. Supported: {SUPPORTED_PROVIDERS}"
+                )
+        self.provider_fallback: list[str] = fallback_list
 
         self.classifier_threshold: float = float(
             os.environ.get("CLASSIFIER_THRESHOLD", str(DEFAULT_CLASSIFIER_THRESHOLD))

--- a/src/mcp_trentina_crunchtools/errors.py
+++ b/src/mcp_trentina_crunchtools/errors.py
@@ -39,8 +39,9 @@ class SanitizationError(AirlockError):
 class QuarantineAgentError(AirlockError):
     """Raised when the Q-Agent (Gemini) call fails."""
 
-    def __init__(self, reason: str) -> None:
+    def __init__(self, reason: str, status_code: int | None = None) -> None:
         super().__init__(f"Q-Agent error: {reason}")
+        self.status_code = status_code
 
 
 class BlockedSourceError(AirlockError):

--- a/src/mcp_trentina_crunchtools/quarantine/agent.py
+++ b/src/mcp_trentina_crunchtools/quarantine/agent.py
@@ -13,10 +13,12 @@ from __future__ import annotations
 import json
 import logging
 import secrets
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pydantic import SecretStr
 
 import httpx
-from pydantic import SecretStr
 
 from ..config import get_config
 from ..errors import QuarantineAgentError
@@ -28,13 +30,13 @@ from .prompts import (
     EXTRACTION_SYSTEM_PROMPT,
     SEARCH_L0_SYSTEM_PROMPT,
 )
-from .providers import get_provider
+from .providers import get_fallback_providers, get_provider
 
 try:
     from ..gateway.context import get_current_profile
 except ImportError:
     # Standalone mode (no gateway)
-    def get_current_profile():
+    def get_current_profile() -> None:  # type: ignore[misc]
         return None
 
 logger = logging.getLogger(__name__)
@@ -67,6 +69,82 @@ def _inject_canary(system_prompt: str, canary: str) -> str:
 def _check_canary(parsed: dict[str, Any], canary: str) -> bool:
     """Check if the canary leaked into the Q-Agent response."""
     return canary in json.dumps(parsed)
+
+
+_RETRYABLE_STATUS_CODES = frozenset({429, 503})
+
+
+def _is_retryable(exc: QuarantineAgentError) -> bool:
+    """Return True if the error is transient and worth trying the next provider."""
+    if exc.status_code is not None:
+        return exc.status_code in _RETRYABLE_STATUS_CODES
+    msg = str(exc).lower()
+    return "timed out" in msg or "unreachable" in msg
+
+
+async def _call_with_fallback(
+    content: str,
+    system_prompt: str,
+    response_schema: dict[str, Any],
+    user_prompt: str | None = None,
+) -> tuple[dict[str, Any], str]:
+    """Call the provider chain, falling back on retryable errors.
+
+    Builds an ordered list: [primary] + fallback_chain. Iterates until one
+    succeeds, a non-retryable error is raised, or all providers are exhausted.
+    """
+    profile = get_current_profile()
+
+    # Determine primary provider and key from profile or global config
+    if profile is not None:
+        primary_name = profile.defense.provider or get_config().provider
+        if primary_name == "ollama":
+            primary_key = None
+        else:
+            llm_keys = getattr(profile, "llm_keys", {})
+            if primary_name not in llm_keys:
+                raise QuarantineAgentError(
+                    f"Profile {profile.name!r} has no API key configured for provider "
+                    f"{primary_name!r}. Add llm_keys.{primary_name} to the profile configuration."
+                )
+            primary_key = llm_keys[primary_name].api_key
+    else:
+        primary_name = get_config().provider
+        primary_key = None  # get_provider() resolves global key
+
+    chain = [(primary_name, primary_key), *get_fallback_providers(profile)]
+
+    last_exc: QuarantineAgentError | None = None
+    for i, (name, key) in enumerate(chain):
+        try:
+            return await _call_gemini(
+                content=content,
+                system_prompt=system_prompt,
+                response_schema=response_schema,
+                user_prompt=user_prompt,
+                provider_name=name,
+                _api_key_override=key,
+                _bypass_profile=True,
+            )
+        except QuarantineAgentError as exc:
+            if not _is_retryable(exc):
+                raise
+            last_exc = exc
+            next_name = chain[i + 1][0] if i + 1 < len(chain) else None
+            if next_name:
+                logger.warning(
+                    "provider fallback: %s failed (%s), trying %s",
+                    name, exc, next_name,
+                )
+            else:
+                logger.warning(
+                    "provider fallback: %s failed (%s), all providers exhausted",
+                    name, exc,
+                )
+
+    raise QuarantineAgentError(
+        f"all providers exhausted: {[n for n, _ in chain]}"
+    ) from last_exc
 
 
 def _build_request_body(
@@ -121,6 +199,8 @@ async def _call_gemini(
     response_schema: dict[str, Any],
     user_prompt: str | None = None,
     provider_name: str | None = None,
+    _api_key_override: SecretStr | None = None,
+    _bypass_profile: bool = False,
 ) -> tuple[dict[str, Any], str]:
     """Call the configured LLM provider and return parsed JSON response and canary.
 
@@ -130,6 +210,8 @@ async def _call_gemini(
 
     Args:
         provider_name: LLM provider override (default: global config or profile override).
+        _api_key_override: Explicit API key — skips profile resolution when _bypass_profile=True.
+        _bypass_profile: Set by _call_with_fallback() to indicate key + provider are pre-resolved.
     """
     canary = _generate_canary()
     prompted = _inject_canary(system_prompt, canary)
@@ -138,43 +220,54 @@ async def _call_gemini(
     if user_prompt:
         user_text = f"{user_prompt}\n\n---\n\n{content}"
 
-    # Check for profile context (gateway mode with per-profile keys)
-    profile = get_current_profile()
-    api_key: SecretStr | None = None
-    model: str | None = None
-
-    if profile is not None:
-        # Gateway mode: REQUIRE per-profile API key for key-based providers only
-        resolved_provider = provider_name or profile.defense.provider or get_config().provider
-
-        # Ollama doesn't use API keys, skip the key check
-        if resolved_provider == "ollama":
-            api_key = None
-        else:
-            if resolved_provider not in profile.llm_keys:
-                raise QuarantineAgentError(
-                    f"Profile {profile.name!r} has no API key configured for provider "
-                    f"{resolved_provider!r}. Add llm_keys.{resolved_provider} to the "
-                    f"profile configuration."
-                )
-            api_key = profile.llm_keys[resolved_provider].api_key
-
-        model = profile.defense.model
-        logger.info(
-            "quarantine: profile=%s using dedicated key for provider=%s model=%s",
-            profile.name,
-            resolved_provider,
-            model or "(default)",
-        )
-
+    if _bypass_profile:
+        # Called from _call_with_fallback() — provider and key already resolved
+        profile = get_current_profile()
+        model = getattr(getattr(profile, "defense", None), "model", None) if profile else None
         provider = get_provider(
-            provider_name=resolved_provider,
-            api_key=api_key,
+            provider_name=provider_name,
+            api_key=_api_key_override,
             model=model,
         )
     else:
-        # Standalone mode — use global config
-        provider = get_provider(provider_name)
+        # Check for profile context (gateway mode with per-profile keys)
+        profile = get_current_profile()
+        api_key: SecretStr | None = None
+        model = None
+
+        if profile is not None:
+            # Gateway mode: REQUIRE per-profile API key for key-based providers only
+            resolved_provider = provider_name or profile.defense.provider or get_config().provider
+
+            # Ollama doesn't use API keys, skip the key check
+            if resolved_provider == "ollama":
+                api_key = None
+            else:
+                if resolved_provider not in profile.llm_keys:
+                    raise QuarantineAgentError(
+                        f"Profile {profile.name!r} has no API key configured for provider "
+                        f"{resolved_provider!r}. Add llm_keys.{resolved_provider} to the "
+                        f"profile configuration."
+                    )
+                api_key = profile.llm_keys[resolved_provider].api_key
+
+            model = profile.defense.model
+            logger.info(
+                "quarantine: profile=%s using dedicated key for provider=%s model=%s",
+                profile.name,
+                resolved_provider,
+                model or "(default)",
+            )
+
+            provider = get_provider(
+                provider_name=resolved_provider,
+                api_key=api_key,
+                model=model,
+            )
+        else:
+            # Standalone mode — use global config
+            provider = get_provider(provider_name)
+
     provider_result = await provider.generate(
         system_prompt=prompted,
         user_content=user_text,
@@ -217,13 +310,22 @@ async def quarantine_extract(
         provider_name: LLM provider override (default: global config).
     """
     try:
-        parsed, _canary = await _call_gemini(
-            content=content,
-            system_prompt=EXTRACTION_SYSTEM_PROMPT,
-            response_schema=EXTRACTION_RESPONSE_SCHEMA,
-            user_prompt=prompt,
-            provider_name=provider_name,
-        )
+        if provider_name is not None:
+            # Explicit provider requested (e.g. benchmark) — no fallback
+            parsed, _canary = await _call_gemini(
+                content=content,
+                system_prompt=EXTRACTION_SYSTEM_PROMPT,
+                response_schema=EXTRACTION_RESPONSE_SCHEMA,
+                user_prompt=prompt,
+                provider_name=provider_name,
+            )
+        else:
+            parsed, _canary = await _call_with_fallback(
+                content=content,
+                system_prompt=EXTRACTION_SYSTEM_PROMPT,
+                response_schema=EXTRACTION_RESPONSE_SCHEMA,
+                user_prompt=prompt,
+            )
     except QuarantineAgentError:
         config = get_config()
         if config.fallback == "fail":
@@ -285,12 +387,20 @@ async def quarantine_detect(
         scan_content = f"{layer1_context}\n\n---\n\n{content}"
 
     try:
-        parsed, _canary = await _call_gemini(
-            content=scan_content,
-            system_prompt=DETECTION_SYSTEM_PROMPT,
-            response_schema=DETECTION_RESPONSE_SCHEMA,
-            provider_name=provider_name,
-        )
+        if provider_name is not None:
+            # Explicit provider requested (e.g. benchmark) — no fallback
+            parsed, _canary = await _call_gemini(
+                content=scan_content,
+                system_prompt=DETECTION_SYSTEM_PROMPT,
+                response_schema=DETECTION_RESPONSE_SCHEMA,
+                provider_name=provider_name,
+            )
+        else:
+            parsed, _canary = await _call_with_fallback(
+                content=scan_content,
+                system_prompt=DETECTION_SYSTEM_PROMPT,
+                response_schema=DETECTION_RESPONSE_SCHEMA,
+            )
     except QuarantineAgentError as exc:
         logger.warning("Q-Agent detection failed: %s", exc)
         return {

--- a/src/mcp_trentina_crunchtools/quarantine/providers/__init__.py
+++ b/src/mcp_trentina_crunchtools/quarantine/providers/__init__.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 _provider_cache: dict[tuple[str, str, str], Provider] = {}
 
-__all__ = ["Provider", "ProviderResult", "get_provider"]
+__all__ = ["Provider", "ProviderResult", "get_provider", "get_fallback_providers"]
 
 _DEFAULT_GEMINI_MODEL = "gemini-2.5-flash-lite"
 
@@ -95,10 +95,10 @@ def get_provider(
             from .ollama import OllamaProvider
 
             # Ollama doesn't use API keys
-            provider = OllamaProvider(
-                model=resolved_model if resolved_model != _DEFAULT_GEMINI_MODEL else config.ollama_model,
-                base_url=config.ollama_base_url,
+            ollama_model = (
+                resolved_model if resolved_model != _DEFAULT_GEMINI_MODEL else config.ollama_model
             )
+            provider = OllamaProvider(model=ollama_model, base_url=config.ollama_base_url)
 
         case _:
             raise QuarantineAgentError(
@@ -114,6 +114,56 @@ def get_provider(
         "override" if api_key else "global",
     )
     return provider
+
+
+def get_fallback_providers(profile: object = None) -> list[tuple[str, SecretStr | None]]:
+    """Resolve the configured fallback chain to (provider_name, api_key) pairs.
+
+    Skips providers that have no API key in the current context — a warning
+    is logged so operators know the chain is shorter than configured.
+
+    Args:
+        profile: Gateway profile object (has .llm_keys dict). None in standalone mode.
+
+    Returns:
+        List of (provider_name, api_key_or_none) tuples ready for _call_gemini().
+    """
+    config = get_config()
+    result: list[tuple[str, SecretStr | None]] = []
+
+    for name in config.provider_fallback:
+        if name == "ollama":
+            result.append((name, None))
+            continue
+
+        if profile is not None:
+            # Gateway mode: require per-profile key, skip if absent
+            llm_keys = getattr(profile, "llm_keys", {})
+            if name not in llm_keys:
+                logger.warning(
+                    "provider fallback: skipping %r — no key in profile %r",
+                    name,
+                    getattr(profile, "name", "?"),
+                )
+                continue
+            result.append((name, llm_keys[name].api_key))
+        else:
+            # Standalone mode: use global config key
+            key_str: str = ""
+            if name == "gemini":
+                key_str = config.api_key.get_secret_value()
+            elif name == "openai":
+                key_str = config.openai_api_key
+            elif name == "anthropic":
+                key_str = config.anthropic_api_key
+            if not key_str:
+                logger.warning(
+                    "provider fallback: skipping %r — no global API key configured", name
+                )
+                continue
+            result.append((name, SecretStr(key_str)))
+
+    return result
 
 
 def reset_provider() -> None:

--- a/src/mcp_trentina_crunchtools/quarantine/providers/anthropic.py
+++ b/src/mcp_trentina_crunchtools/quarantine/providers/anthropic.py
@@ -88,7 +88,9 @@ class AnthropicProvider(Provider):
             )
 
         except httpx.HTTPStatusError as exc:
-            raise QuarantineAgentError(f"HTTP {exc.response.status_code}") from exc
+            raise QuarantineAgentError(
+                f"HTTP {exc.response.status_code}", status_code=exc.response.status_code
+            ) from exc
         except httpx.TimeoutException as exc:
             raise QuarantineAgentError("Request timed out") from exc
         except httpx.RequestError as exc:

--- a/src/mcp_trentina_crunchtools/quarantine/providers/gemini.py
+++ b/src/mcp_trentina_crunchtools/quarantine/providers/gemini.py
@@ -77,7 +77,9 @@ class GeminiProvider(Provider):
             )
 
         except httpx.HTTPStatusError as exc:
-            raise QuarantineAgentError(f"HTTP {exc.response.status_code}") from exc
+            raise QuarantineAgentError(
+                f"HTTP {exc.response.status_code}", status_code=exc.response.status_code
+            ) from exc
         except httpx.TimeoutException as exc:
             raise QuarantineAgentError("Request timed out") from exc
         except httpx.RequestError as exc:

--- a/src/mcp_trentina_crunchtools/quarantine/providers/ollama.py
+++ b/src/mcp_trentina_crunchtools/quarantine/providers/ollama.py
@@ -72,7 +72,9 @@ class OllamaProvider(Provider):
             )
 
         except httpx.HTTPStatusError as exc:
-            raise QuarantineAgentError(f"HTTP {exc.response.status_code}") from exc
+            raise QuarantineAgentError(
+                f"HTTP {exc.response.status_code}", status_code=exc.response.status_code
+            ) from exc
         except httpx.TimeoutException as exc:
             raise QuarantineAgentError("Request timed out") from exc
         except httpx.ConnectError as exc:

--- a/src/mcp_trentina_crunchtools/quarantine/providers/openai.py
+++ b/src/mcp_trentina_crunchtools/quarantine/providers/openai.py
@@ -113,7 +113,9 @@ class OpenAIProvider(Provider):
             )
 
         except httpx.HTTPStatusError as exc:
-            raise QuarantineAgentError(f"HTTP {exc.response.status_code}") from exc
+            raise QuarantineAgentError(
+                f"HTTP {exc.response.status_code}", status_code=exc.response.status_code
+            ) from exc
         except httpx.TimeoutException as exc:
             raise QuarantineAgentError("Request timed out") from exc
         except httpx.RequestError as exc:

--- a/tests/test_provider_fallback.py
+++ b/tests/test_provider_fallback.py
@@ -1,0 +1,430 @@
+"""Tests for the automatic provider fallback chain (issue #42)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from mcp_trentina_crunchtools.config import get_config
+from mcp_trentina_crunchtools.errors import ConfigError, QuarantineAgentError
+from mcp_trentina_crunchtools.quarantine.agent import (
+    _call_with_fallback,
+    _is_retryable,
+)
+from mcp_trentina_crunchtools.quarantine.providers import (
+    get_fallback_providers,
+    reset_provider,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_config_and_providers(monkeypatch):
+    """Clear singletons between tests."""
+    import mcp_trentina_crunchtools.config as cfg_mod
+
+    monkeypatch.setattr(cfg_mod, "_config", None)
+    reset_provider()
+    yield
+    reset_provider()
+
+
+# ---------------------------------------------------------------------------
+# _is_retryable
+# ---------------------------------------------------------------------------
+
+
+class TestIsRetryable:
+    def test_429_is_retryable(self):
+        exc = QuarantineAgentError("rate limited", status_code=429)
+        assert _is_retryable(exc)
+
+    def test_503_is_retryable(self):
+        exc = QuarantineAgentError("service unavailable", status_code=503)
+        assert _is_retryable(exc)
+
+    def test_400_not_retryable(self):
+        exc = QuarantineAgentError("bad request", status_code=400)
+        assert not _is_retryable(exc)
+
+    def test_401_not_retryable(self):
+        exc = QuarantineAgentError("unauthorized", status_code=401)
+        assert not _is_retryable(exc)
+
+    def test_403_not_retryable(self):
+        exc = QuarantineAgentError("forbidden", status_code=403)
+        assert not _is_retryable(exc)
+
+    def test_timeout_message_retryable(self):
+        exc = QuarantineAgentError("Request timed out")
+        assert _is_retryable(exc)
+
+    def test_unreachable_message_retryable(self):
+        exc = QuarantineAgentError("Ollama unreachable at http://localhost:11434: ...")
+        assert _is_retryable(exc)
+
+    def test_json_error_not_retryable(self):
+        exc = QuarantineAgentError("Invalid JSON in provider response")
+        assert not _is_retryable(exc)
+
+    def test_canary_error_not_retryable(self):
+        exc = QuarantineAgentError("SECURITY: canary token leaked")
+        assert not _is_retryable(exc)
+
+    def test_no_status_code_generic_error_not_retryable(self):
+        exc = QuarantineAgentError("GEMINI_API_KEY not configured")
+        assert not _is_retryable(exc)
+
+
+# ---------------------------------------------------------------------------
+# Config parsing
+# ---------------------------------------------------------------------------
+
+
+class TestConfigFallbackParsing:
+    def test_empty_fallback_defaults_to_empty_list(self, monkeypatch):
+        monkeypatch.delenv("TRENTINA_PROVIDER_FALLBACK", raising=False)
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        config = get_config()
+        assert config.provider_fallback == []
+
+    def test_single_fallback(self, monkeypatch):
+        monkeypatch.setenv("TRENTINA_PROVIDER_FALLBACK", "openai")
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        config = get_config()
+        assert config.provider_fallback == ["openai"]
+
+    def test_multiple_fallbacks(self, monkeypatch):
+        monkeypatch.setenv("TRENTINA_PROVIDER_FALLBACK", "openai,anthropic")
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        config = get_config()
+        assert config.provider_fallback == ["openai", "anthropic"]
+
+    def test_whitespace_stripped(self, monkeypatch):
+        monkeypatch.setenv("TRENTINA_PROVIDER_FALLBACK", " openai , anthropic ")
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        config = get_config()
+        assert config.provider_fallback == ["openai", "anthropic"]
+
+    def test_invalid_provider_raises_config_error(self, monkeypatch):
+        monkeypatch.setenv("TRENTINA_PROVIDER_FALLBACK", "invalid-llm")
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        with pytest.raises(ConfigError, match="Unknown fallback provider"):
+            get_config()
+
+    def test_ollama_valid_in_chain(self, monkeypatch):
+        monkeypatch.setenv("TRENTINA_PROVIDER_FALLBACK", "ollama")
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        config = get_config()
+        assert config.provider_fallback == ["ollama"]
+
+
+# ---------------------------------------------------------------------------
+# get_fallback_providers (standalone mode)
+# ---------------------------------------------------------------------------
+
+
+class TestGetFallbackProvidersStandalone:
+    def test_empty_chain_returns_empty(self, monkeypatch):
+        monkeypatch.delenv("TRENTINA_PROVIDER_FALLBACK", raising=False)
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        get_config()
+        assert get_fallback_providers() == []
+
+    def test_openai_with_key(self, monkeypatch):
+        monkeypatch.setenv("TRENTINA_PROVIDER_FALLBACK", "openai")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        get_config()
+        chain = get_fallback_providers()
+        assert len(chain) == 1
+        name, key = chain[0]
+        assert name == "openai"
+        assert key is not None
+        assert key.get_secret_value() == "sk-test"
+
+    def test_provider_without_key_skipped(self, monkeypatch, caplog):
+        monkeypatch.setenv("TRENTINA_PROVIDER_FALLBACK", "openai")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        get_config()
+        chain = get_fallback_providers()
+        assert chain == []
+        assert "skipping" in caplog.text
+
+    def test_ollama_has_none_key(self, monkeypatch):
+        monkeypatch.setenv("TRENTINA_PROVIDER_FALLBACK", "ollama")
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        get_config()
+        chain = get_fallback_providers()
+        assert len(chain) == 1
+        name, key = chain[0]
+        assert name == "ollama"
+        assert key is None
+
+
+# ---------------------------------------------------------------------------
+# _call_with_fallback integration tests (mocked provider.generate)
+# ---------------------------------------------------------------------------
+
+FAKE_EXTRACTED = {
+    "extracted_text": "hello world",
+    "confidence": "high",
+    "injection_detected": False,
+}
+FAKE_SCHEMA = {
+    "type": "object",
+    "properties": {"extracted_text": {"type": "string"}},
+}
+
+
+def make_provider_result(text: str) -> object:
+    from mcp_trentina_crunchtools.quarantine.providers.base import ProviderResult
+
+    return ProviderResult(text=text, input_tokens=10, output_tokens=5)
+
+
+def make_good_response() -> str:
+    return json.dumps(FAKE_EXTRACTED)
+
+
+def make_429_error() -> QuarantineAgentError:
+    return QuarantineAgentError("HTTP 429", status_code=429)
+
+
+def make_503_error() -> QuarantineAgentError:
+    return QuarantineAgentError("HTTP 503", status_code=503)
+
+
+def make_400_error() -> QuarantineAgentError:
+    return QuarantineAgentError("HTTP 400", status_code=400)
+
+
+@pytest.mark.asyncio
+class TestCallWithFallback:
+    async def test_primary_succeeds_no_fallback_called(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        monkeypatch.delenv("TRENTINA_PROVIDER_FALLBACK", raising=False)
+        get_config()
+
+        call_count = {"n": 0}
+        good_result = make_provider_result(make_good_response())
+
+        async def fake_generate(*_args, **_kwargs):
+            call_count["n"] += 1
+            return good_result
+
+        with patch(
+            "mcp_trentina_crunchtools.quarantine.providers.gemini.GeminiProvider.generate",
+            new=fake_generate,
+        ):
+            result, _ = await _call_with_fallback(
+                content="test content",
+                system_prompt="test prompt",
+                response_schema=FAKE_SCHEMA,
+            )
+
+        assert call_count["n"] == 1
+        assert result["extracted_text"] == "hello world"
+
+    async def test_429_triggers_fallback(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        monkeypatch.setenv("TRENTINA_PROVIDER_FALLBACK", "openai")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        get_config()
+
+        gemini_mock = AsyncMock(side_effect=make_429_error())
+        openai_result = make_provider_result(make_good_response())
+        openai_mock = AsyncMock(return_value=openai_result)
+
+        with (
+            patch(
+                "mcp_trentina_crunchtools.quarantine.providers.gemini.GeminiProvider.generate",
+                new=gemini_mock,
+            ),
+            patch(
+                "mcp_trentina_crunchtools.quarantine.providers.openai.OpenAIProvider.generate",
+                new=openai_mock,
+            ),
+        ):
+            result, _ = await _call_with_fallback(
+                content="test content",
+                system_prompt="test prompt",
+                response_schema=FAKE_SCHEMA,
+            )
+
+        gemini_mock.assert_called_once()
+        openai_mock.assert_called_once()
+        assert result["extracted_text"] == "hello world"
+
+    async def test_503_triggers_fallback(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        monkeypatch.setenv("TRENTINA_PROVIDER_FALLBACK", "openai")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        get_config()
+
+        gemini_mock = AsyncMock(side_effect=make_503_error())
+        openai_result = make_provider_result(make_good_response())
+        openai_mock = AsyncMock(return_value=openai_result)
+
+        with (
+            patch(
+                "mcp_trentina_crunchtools.quarantine.providers.gemini.GeminiProvider.generate",
+                new=gemini_mock,
+            ),
+            patch(
+                "mcp_trentina_crunchtools.quarantine.providers.openai.OpenAIProvider.generate",
+                new=openai_mock,
+            ),
+        ):
+            result, _ = await _call_with_fallback(
+                content="test content",
+                system_prompt="test prompt",
+                response_schema=FAKE_SCHEMA,
+            )
+
+        gemini_mock.assert_called_once()
+        openai_mock.assert_called_once()
+        assert result["extracted_text"] == "hello world"
+
+    async def test_400_does_not_trigger_fallback(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        monkeypatch.setenv("TRENTINA_PROVIDER_FALLBACK", "openai")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        get_config()
+
+        gemini_mock = AsyncMock(side_effect=make_400_error())
+        openai_mock = AsyncMock()
+
+        with (
+            patch(
+                "mcp_trentina_crunchtools.quarantine.providers.gemini.GeminiProvider.generate",
+                new=gemini_mock,
+            ),
+            patch(
+                "mcp_trentina_crunchtools.quarantine.providers.openai.OpenAIProvider.generate",
+                new=openai_mock,
+            ),pytest.raises(QuarantineAgentError, match="HTTP 400")
+        ):
+            await _call_with_fallback(
+                content="test content",
+                system_prompt="test prompt",
+                response_schema=FAKE_SCHEMA,
+            )
+
+        gemini_mock.assert_called_once()
+        openai_mock.assert_not_called()
+
+    async def test_all_providers_exhausted_raises(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        monkeypatch.setenv("TRENTINA_PROVIDER_FALLBACK", "openai")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        get_config()
+
+        gemini_mock = AsyncMock(side_effect=make_429_error())
+        openai_mock = AsyncMock(side_effect=make_503_error())
+
+        with (
+            patch(
+                "mcp_trentina_crunchtools.quarantine.providers.gemini.GeminiProvider.generate",
+                new=gemini_mock,
+            ),
+            patch(
+                "mcp_trentina_crunchtools.quarantine.providers.openai.OpenAIProvider.generate",
+                new=openai_mock,
+            ),pytest.raises(QuarantineAgentError, match="all providers exhausted")
+        ):
+            await _call_with_fallback(
+                content="test content",
+                system_prompt="test prompt",
+                response_schema=FAKE_SCHEMA,
+            )
+
+        gemini_mock.assert_called_once()
+        openai_mock.assert_called_once()
+
+    async def test_empty_chain_single_provider_fails_raises(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        monkeypatch.delenv("TRENTINA_PROVIDER_FALLBACK", raising=False)
+        get_config()
+
+        gemini_mock = AsyncMock(side_effect=make_429_error())
+
+        with patch(
+            "mcp_trentina_crunchtools.quarantine.providers.gemini.GeminiProvider.generate",
+            new=gemini_mock,
+        ), pytest.raises(QuarantineAgentError, match="all providers exhausted"):
+            await _call_with_fallback(
+                content="test content",
+                system_prompt="test prompt",
+                response_schema=FAKE_SCHEMA,
+            )
+
+    async def test_timeout_triggers_fallback(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        monkeypatch.setenv("TRENTINA_PROVIDER_FALLBACK", "openai")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        get_config()
+
+        gemini_mock = AsyncMock(
+            side_effect=QuarantineAgentError("Request timed out")
+        )
+        openai_result = make_provider_result(make_good_response())
+        openai_mock = AsyncMock(return_value=openai_result)
+
+        with (
+            patch(
+                "mcp_trentina_crunchtools.quarantine.providers.gemini.GeminiProvider.generate",
+                new=gemini_mock,
+            ),
+            patch(
+                "mcp_trentina_crunchtools.quarantine.providers.openai.OpenAIProvider.generate",
+                new=openai_mock,
+            ),
+        ):
+            result, _ = await _call_with_fallback(
+                content="test content",
+                system_prompt="test prompt",
+                response_schema=FAKE_SCHEMA,
+            )
+
+        assert result["extracted_text"] == "hello world"
+
+    async def test_three_provider_chain(self, monkeypatch):
+        """Gemini fails, OpenAI fails, Anthropic succeeds."""
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        monkeypatch.setenv("TRENTINA_PROVIDER_FALLBACK", "openai,anthropic")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "ant-test")
+        get_config()
+
+        gemini_mock = AsyncMock(side_effect=make_429_error())
+        openai_mock = AsyncMock(side_effect=make_503_error())
+        anthropic_result = make_provider_result(make_good_response())
+        anthropic_mock = AsyncMock(return_value=anthropic_result)
+
+        with (
+            patch(
+                "mcp_trentina_crunchtools.quarantine.providers.gemini.GeminiProvider.generate",
+                new=gemini_mock,
+            ),
+            patch(
+                "mcp_trentina_crunchtools.quarantine.providers.openai.OpenAIProvider.generate",
+                new=openai_mock,
+            ),
+            patch(
+                "mcp_trentina_crunchtools.quarantine.providers.anthropic.AnthropicProvider.generate",
+                new=anthropic_mock,
+            ),
+        ):
+            result, _ = await _call_with_fallback(
+                content="test content",
+                system_prompt="test prompt",
+                response_schema=FAKE_SCHEMA,
+            )
+
+        gemini_mock.assert_called_once()
+        openai_mock.assert_called_once()
+        anthropic_mock.assert_called_once()
+        assert result["extracted_text"] == "hello world"


### PR DESCRIPTION
## Summary

- Adds resilient LLM provider selection: when the primary provider fails with a retryable error (HTTP 429, 503, timeout, connect error), Trentina tries the next provider in a configured chain before falling back to L1-only mode
- Non-retryable errors (400, 401, 403, JSON decode) short-circuit immediately
- Configured via `TRENTINA_PROVIDER_FALLBACK=openai,anthropic` (comma-separated, empty = current behavior unchanged)
- `search_grounded()` is Gemini-only and excluded from fallback chain
- Explicit `provider_name` overrides (benchmark path) bypass the chain and call the named provider directly

Closes #42

## Changes

- `errors.py`: `QuarantineAgentError` gains a `status_code: int | None` field
- `config.py`: new `provider_fallback: list[str]` field from `TRENTINA_PROVIDER_FALLBACK`
- `providers/{gemini,openai,anthropic,ollama}.py`: pass `status_code` on HTTP errors
- `providers/__init__.py`: `get_fallback_providers()` resolves the chain to `(name, key)` pairs, skipping providers with no key
- `agent.py`: `_is_retryable()`, `_call_with_fallback()` — `quarantine_extract` and `quarantine_detect` use the fallback chain
- `pyproject.toml`: `pythonpath = ["src"]` for correct test isolation in git worktrees
- `tests/test_provider_fallback.py`: 28 new tests

## Test plan

- [x] `_is_retryable()` — 10 cases covering retryable (429, 503, timeout, unreachable) and non-retryable (400, 401, 403, JSON error, canary, generic) errors
- [x] Config parsing — empty, single, multiple, whitespace, invalid provider, ollama
- [x] `get_fallback_providers()` — empty chain, key present, key absent (skipped), ollama (None key)
- [x] `_call_with_fallback()` — primary succeeds, 429/503/timeout triggers fallback, 400 does not trigger fallback, all exhausted raises, three-provider chain
- [x] `uv run ruff check src tests` — clean
- [x] `uv run mypy src` — clean
- [x] `uv run pytest -v` — 697 passed, 54 skipped, 3 pre-existing FastMCP API compat failures (unrelated, tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)