### PR TITLE
fix(gateway): stop tools/list cache-eviction stampede

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ ignore = [
     "S101",     # assert allowed in tests
     "TRY003",   # long exception messages ok
     "PLR0913",  # many arguments ok for tools
+    "PLR0917",  # many positional arguments ok for tools (newer ruff enforces this)
     "PLR2004",  # magic numbers ok (HTTP status codes, limits)
     "PLW0603",  # global statement ok for singletons
     "PIE790",   # pass in empty classes ok

--- a/src/mcp_trentina_crunchtools/gateway/backend.py
+++ b/src/mcp_trentina_crunchtools/gateway/backend.py
@@ -2,8 +2,12 @@
 
 Opens a fresh MCP session per call (streamablehttp_client creates anyio
 task groups that cannot cross task boundaries, so pooling is not viable).
-Caches tool lists per URL indefinitely — invalidated on backend failure
-or explicit flush, persisted in SQLite across restarts.
+Caches tool lists per URL indefinitely — invalidated only on explicit flush
+or reconnect, persisted in SQLite across restarts. Crucially, a fetch failure
+never evicts: a cached backend keeps being served from cache through a transient
+outage, so a backend blip can never wipe the cache (which previously triggered a
+fan-out stampede). Concurrent misses for the same URL coalesce into a single
+in-flight fetch.
 """
 
 from __future__ import annotations
@@ -36,6 +40,8 @@ class BackendCall:
 
 
 _tool_list_cache: dict[str, list[dict[str, Any]]] = {}
+
+_inflight: dict[str, asyncio.Task[list[dict[str, Any]]]] = {}
 
 _on_evict_callbacks: list[Any] = []
 
@@ -88,6 +94,7 @@ def load_tool_list_cache() -> int:
 def reset_tool_list_cache() -> None:
     """Clear the in-memory cache without touching SQLite (for testing)."""
     _tool_list_cache.clear()
+    _inflight.clear()
     _on_evict_callbacks.clear()
 
 
@@ -96,21 +103,51 @@ async def list_backend_tools(
 ) -> list[dict[str, Any]]:
     """Fetch the tool list from one backend MCP server.
 
-    Returns from in-memory cache if available. On miss, fetches from
-    the backend and persists to SQLite.
+    A cached backend is always served from cache — the fast path never touches
+    the transport or circuit breaker. Because the cache is never evicted on
+    failure (only on explicit flush/reconnect), a transient backend outage can
+    neither wipe nor bypass the last-known-good list: it keeps being served
+    here. On a genuine miss, concurrent callers coalesce onto one in-flight
+    fetch per URL.
 
     Raises:
         BackendCallError: connection failure, protocol error, timeout, or
-            circuit open.
+            circuit open — only on a cold miss with nothing cached to serve.
+    """
+    cached = _tool_list_cache.get(backend.url)
+    if cached is not None:
+        return cached
+
+    inflight = _inflight.get(backend.url)
+    if inflight is None:
+        inflight = asyncio.ensure_future(_single_flight_fetch(backend_name, backend))
+        _inflight[backend.url] = inflight
+    return await inflight
+
+
+async def _single_flight_fetch(
+    backend_name: str, backend: Backend,
+) -> list[dict[str, Any]]:
+    """Run one fetch and drop its in-flight slot when done."""
+    try:
+        return await _fetch_and_cache(backend_name, backend)
+    finally:
+        _inflight.pop(backend.url, None)
+
+
+async def _fetch_and_cache(
+    backend_name: str, backend: Backend,
+) -> list[dict[str, Any]]:
+    """Fetch one backend's tool list, cache it, and persist to SQLite.
+
+    Only invoked on a cache miss (``list_backend_tools`` serves any cached list
+    directly and never evicts on failure), so there is never a stale entry to
+    fall back on here — a failure simply raises.
     """
     if not breaker.allow(backend.url):
         raise BackendCallError(
             f"backend {backend_name!r} circuit open — skipped"
         )
-
-    cached = _tool_list_cache.get(backend.url)
-    if cached is not None:
-        return cached
 
     headers = backend.headers or None
     try:
@@ -120,7 +157,6 @@ async def list_backend_tools(
         )
     except Exception as exc:
         breaker.record_failure(backend.url)
-        _evict_backend_cache(backend.url)
         logger.warning(
             "gateway: list_tools failed for backend=%s url=%s err=%s",
             backend_name,
@@ -146,6 +182,10 @@ async def call_backend_tool(
 ) -> BackendCall:
     """Invoke a tool on a backend MCP server, returning the raw result.
 
+    A failed call records a circuit failure but deliberately does NOT evict the
+    tool-list cache — a transient call error must not wipe the list and trigger a
+    refetch storm on the next tools/list. The list refreshes only on flush.
+
     Raises:
         BackendCallError: connection failure, protocol error, timeout, or
             circuit open.
@@ -166,7 +206,6 @@ async def call_backend_tool(
         )
     except Exception as exc:
         breaker.record_failure(backend.url)
-        _evict_backend_cache(backend.url)
         logger.warning(
             "gateway: call_tool failed backend=%s tool=%s err=%s",
             backend_name,

--- a/src/mcp_trentina_crunchtools/gateway/router.py
+++ b/src/mcp_trentina_crunchtools/gateway/router.py
@@ -43,6 +43,8 @@ NAMESPACE_SEP = "__"
 _profile_tools_cache: dict[str, list[dict[str, Any]]] = {}
 _profile_backend_urls: dict[str, set[str]] = {}
 
+_profile_inflight: dict[str, asyncio.Task[list[dict[str, Any]]]] = {}
+
 
 def _on_backend_evicted(url: str) -> None:
     """Clear any profile cache whose backend set includes this URL."""
@@ -70,6 +72,7 @@ def reset_profile_tools_cache() -> None:
     """Clear the profile-level tool list cache (for testing)."""
     _profile_tools_cache.clear()
     _profile_backend_urls.clear()
+    _profile_inflight.clear()
 
 
 def _audit(
@@ -155,13 +158,40 @@ async def route_jsonrpc(profile: Profile, request: dict[str, Any]) -> dict[str, 
 async def _route_tools_list(profile: Profile, req_id: Any) -> dict[str, Any]:
     """Aggregate tools/list across the profile's backends, filtered and namespaced.
 
-    Checks the per-profile cache first. On miss, queries all backends in
-    parallel and caches the assembled result.
+    Checks the per-profile cache first. On miss, coalesces concurrent callers
+    for the same profile onto a single fan-out (single-flight).
     """
     cached = _profile_tools_cache.get(profile.name)
     if cached is not None:
         return _ok(req_id, {"tools": cached})
 
+    inflight = _profile_inflight.get(profile.name)
+    if inflight is None:
+        inflight = asyncio.ensure_future(_single_flight_build(profile))
+        _profile_inflight[profile.name] = inflight
+    aggregated = await inflight
+    return _ok(req_id, {"tools": aggregated})
+
+
+async def _single_flight_build(profile: Profile) -> list[dict[str, Any]]:
+    """Run one aggregation and drop its in-flight slot when done."""
+    try:
+        return await _build_profile_tools(profile)
+    finally:
+        _profile_inflight.pop(profile.name, None)
+
+
+async def _build_profile_tools(profile: Profile) -> list[dict[str, Any]]:
+    """Fan out to every backend, aggregate, and cache the assembled list.
+
+    The aggregate is cached only when no backend hard-failed (raised). A
+    backend that served a stale list counts as a success; a backend that is
+    both cold and unreachable is skipped and suppresses caching, so the profile
+    self-heals — the next tools/list re-aggregates and picks it up once it
+    recovers. (list_backend_tools single-flights per backend, so re-aggregation
+    while a backend is down stays cheap: healthy backends are cache hits and the
+    down one is a fast circuit-open reject.)
+    """
     await maybe_trigger_compression()
 
     async def _fetch_one(
@@ -189,10 +219,12 @@ async def _route_tools_list(profile: Profile, req_id: Any) -> dict[str, Any]:
     results = await asyncio.gather(*tasks, return_exceptions=True)
 
     aggregated: list[dict[str, Any]] = []
+    any_hard_failed = False
     for (backend_name, _backend), outcome in zip(
         profile.backends.items(), results, strict=True,
     ):
         if isinstance(outcome, BaseException):
+            any_hard_failed = True
             logger.warning(
                 "gateway: tools/list profile=%s backend=%s skipped: %s",
                 profile.name,
@@ -202,11 +234,12 @@ async def _route_tools_list(profile: Profile, req_id: Any) -> dict[str, Any]:
             continue
         aggregated.extend(outcome)
 
-    _profile_tools_cache[profile.name] = aggregated
-    _profile_backend_urls[profile.name] = {
-        b.url for b in profile.backends.values() if not b.is_internal
-    }
-    return _ok(req_id, {"tools": aggregated})
+    if not any_hard_failed:
+        _profile_tools_cache[profile.name] = aggregated
+        _profile_backend_urls[profile.name] = {
+            b.url for b in profile.backends.values() if not b.is_internal
+        }
+    return aggregated
 
 
 async def _route_tools_call(

--- a/tests/test_gateway_backend.py
+++ b/tests/test_gateway_backend.py
@@ -280,7 +280,12 @@ class TestBackendToolListCache:
 
         assert urls_called == [url_a, url_b]
 
-    async def test_circuit_open_does_not_serve_cache(self) -> None:
+    async def test_circuit_open_serves_stale_cache(self) -> None:
+        """A warmed backend serves its cached list even with the circuit open.
+
+        Behavior change: serving the last-known-good list through an outage is
+        the whole point — a backend blip must not collapse the tool list.
+        """
         async def ok_transport(_url: str, _headers: Any) -> _FakeToolsResult:
             return _FakeToolsResult()
 
@@ -294,6 +299,80 @@ class TestBackendToolListCache:
 
         for _ in range(3):
             breaker.record_failure(URL)
+        assert breaker.get_state(URL) is State.OPEN
 
-        with pytest.raises(BackendCallError, match="circuit open"):
+        async def should_not_be_called(_url: str, _headers: Any) -> Any:
+            raise AssertionError("transport called despite warm cache")
+
+        with patch(
+            "mcp_trentina_crunchtools.gateway.backend._do_list_tools",
+            side_effect=should_not_be_called,
+        ):
+            tools = await list_backend_tools("rotv", _backend())
+
+        assert len(tools) == 1
+        assert URL in _tool_list_cache
+
+    async def test_call_failure_does_not_evict_list_cache(self) -> None:
+        """A failed tool call must not evict the cached tool list."""
+        async def ok_list(_url: str, _headers: Any) -> _FakeToolsResult:
+            return _FakeToolsResult()
+
+        with patch(
+            "mcp_trentina_crunchtools.gateway.backend._do_list_tools",
+            side_effect=ok_list,
+        ):
             await list_backend_tools("rotv", _backend())
+        assert URL in _tool_list_cache
+
+        async def fail_call(*_args: Any, **_kwargs: Any) -> Any:
+            raise ConnectionRefusedError("backend hiccup")
+
+        with (
+            patch(
+                "mcp_trentina_crunchtools.gateway.backend._do_call_tool",
+                side_effect=fail_call,
+            ),
+            pytest.raises(BackendCallError),
+        ):
+            await call_backend_tool("rotv", _backend(), "some_tool", {})
+
+        assert URL in _tool_list_cache
+
+        async def should_not_be_called(_url: str, _headers: Any) -> Any:
+            raise AssertionError("transport re-fetched after call failure")
+
+        with patch(
+            "mcp_trentina_crunchtools.gateway.backend._do_list_tools",
+            side_effect=should_not_be_called,
+        ):
+            tools = await list_backend_tools("rotv", _backend())
+        assert len(tools) == 1
+
+    async def test_single_flight_coalesces_concurrent_misses(self) -> None:
+        """Concurrent misses for one URL share a single transport fetch."""
+        import asyncio
+
+        call_count = 0
+        release = asyncio.Event()
+
+        async def slow_transport(_url: str, _headers: Any) -> _FakeToolsResult:
+            nonlocal call_count
+            call_count += 1
+            await release.wait()
+            return _FakeToolsResult()
+
+        with patch(
+            "mcp_trentina_crunchtools.gateway.backend._do_list_tools",
+            side_effect=slow_transport,
+        ):
+            tasks = [
+                asyncio.ensure_future(list_backend_tools("rotv", _backend()))
+                for _ in range(5)
+            ]
+            await asyncio.sleep(0)
+            release.set()
+            results = await asyncio.gather(*tasks)
+
+        assert call_count == 1
+        assert all(len(r) == 1 for r in results)

--- a/tests/test_gateway_router.py
+++ b/tests/test_gateway_router.py
@@ -607,6 +607,86 @@ class TestProfileToolsCache:
         assert "testp" in _profile_tools_cache
         assert "other" in _profile_tools_cache
 
+    async def test_partial_aggregate_not_cached_and_self_heals(self) -> None:
+        """A hard-failed backend suppresses caching so the profile self-heals.
+
+        While a backend raises, the aggregate is returned partial but NOT
+        cached, so the next tools/list re-aggregates. Once the backend recovers,
+        the full list is assembled and cached.
+        """
+        slack_down = True
+
+        async def flaky_list(
+            backend_name: str, _b: Backend,
+        ) -> list[dict[str, Any]]:
+            if backend_name == "mcp-slack" and slack_down:
+                raise BackendCallError("simulated outage")
+            return [{"name": f"{backend_name}_tool", "description": "", "inputSchema": {}}]
+
+        with patch(
+            "mcp_trentina_crunchtools.gateway.router.list_backend_tools",
+            side_effect=flaky_list,
+        ):
+            resp1 = await route_jsonrpc(
+                _profile(), {"jsonrpc": "2.0", "id": 56, "method": "tools/list"},
+            )
+            assert "testp" not in _profile_tools_cache
+            names1 = [str(t["name"]) for t in resp1["result"]["tools"]]
+            assert names1 == [f"mcp-atlassian{NAMESPACE_SEP}mcp-atlassian_tool"]
+
+            slack_down = False
+            resp2 = await route_jsonrpc(
+                _profile(), {"jsonrpc": "2.0", "id": 57, "method": "tools/list"},
+            )
+
+        assert "testp" in _profile_tools_cache
+        names2 = sorted(str(t["name"]) for t in resp2["result"]["tools"])
+        assert names2 == [
+            f"mcp-atlassian{NAMESPACE_SEP}mcp-atlassian_tool",
+            f"mcp-slack{NAMESPACE_SEP}mcp-slack_tool",
+        ]
+
+    async def test_profile_single_flight_coalesces_concurrent_calls(self) -> None:
+        """Concurrent tools/list for one profile share a single fan-out.
+
+        Without single-flight, N concurrent calls over 2 backends would issue
+        2*N backend fetches. With it, each backend is fetched exactly once.
+        """
+        per_backend_calls: dict[str, int] = {}
+        release = asyncio.Event()
+
+        async def slow_list(
+            backend_name: str, _b: Backend,
+        ) -> list[dict[str, Any]]:
+            per_backend_calls[backend_name] = per_backend_calls.get(backend_name, 0) + 1
+            await release.wait()
+            return [{"name": f"{backend_name}_tool", "description": "", "inputSchema": {}}]
+
+        with patch(
+            "mcp_trentina_crunchtools.gateway.router.list_backend_tools",
+            side_effect=slow_list,
+        ):
+            calls = [
+                asyncio.ensure_future(
+                    route_jsonrpc(
+                        _profile(),
+                        {"jsonrpc": "2.0", "id": 60 + i, "method": "tools/list"},
+                    )
+                )
+                for i in range(4)
+            ]
+            await asyncio.sleep(0)
+            release.set()
+            responses = await asyncio.gather(*calls)
+
+        assert per_backend_calls == {"mcp-slack": 1, "mcp-atlassian": 1}
+        for resp in responses:
+            names = sorted(str(t["name"]) for t in resp["result"]["tools"])
+            assert names == [
+                f"mcp-atlassian{NAMESPACE_SEP}mcp-atlassian_tool",
+                f"mcp-slack{NAMESPACE_SEP}mcp-slack_tool",
+            ]
+
 
 class TestProfileContext:
     """Covers the ContextVar reset shipped untested in 4d44916."""


### PR DESCRIPTION
## Summary

The backend tool-list cache in `gateway/backend.py` deleted its entry (in-memory **and** SQLite) on *any* failure — from both the list-fetch path and, more damagingly, the tool-call path. A transient backend failure (the recent DNS AAAA→Cloudflare outage) therefore **wiped the persistent cache**, and under a client reconnect-storm the cold refetches timed out before repopulating it, re-evicting on each attempt. With no single-flight, every concurrent `tools/list` independently fanned out to all ~20 backends, so the gateway hammered itself into perpetual `-32001` timeouts.

### Changes
- **`backend.py`** — never evict on failure (list *or* call paths). Serve the cached list from the fast path so a cached backend survives a transient outage; refresh only via explicit `cache_flush`/`reconnect_backend`. Coalesce concurrent misses per URL onto a single in-flight fetch.
- **`router.py`** — single-flight the per-profile fan-out; cache the aggregate only when no backend hard-failed, so a recovered backend self-heals instead of a partial list sticking.
- Explicit-eviction helpers (`cache_flush`, `reconnect_backend`) unchanged.

## Test plan
- Rewrote `test_circuit_open_does_not_serve_cache` → `test_circuit_open_serves_stale_cache` (serving stale is now intended behavior).
- Added: serve-stale, `call_failure_does_not_evict_list_cache`, backend single-flight coalesce; router `partial_aggregate_not_cached_and_self_heals`, profile single-flight coalesce.
- `uv run ruff check src tests` ✅ · `uv run mypy src` ✅ · `uv run pytest` → **683 passed, 54 skipped** ✅ · gourmand slop check → **0 violations** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)